### PR TITLE
PALLADIO-498 / COMMONS-33

### DIFF
--- a/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/META-INF/MANIFEST.MF
+++ b/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/META-INF/MANIFEST.MF
@@ -7,6 +7,8 @@ Bundle-Vendor: sdq.ipd.uka.de
 Require-Bundle: de.uka.ipd.sdq.stoex,
  de.uka.ipd.sdq.stoex.analyser,
  org.palladiosimulator.pcm,
- de.uka.ipd.sdq.errorhandling
+ de.uka.ipd.sdq.errorhandling,
+ org.palladiosimulator.commons.stoex
 Export-Package: de.uka.ipd.sdq.pcm.stochasticexpressions
 Bundle-RequiredExecutionEnvironment: JavaSE-11
+Automatic-Module-Name: de.uka.ipd.sdq.pcm.stochasticexpressions

--- a/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/plugin.xml
+++ b/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/plugin.xml
@@ -8,5 +8,11 @@
             name="StoEx Type Inference">
       </client>
    </extension>
+   <extension
+         point="org.palladiosimulator.commons.stoex.parseresultpostprocessor">
+      <class
+            class="de.uka.ipd.sdq.pcm.stochasticexpressions.CharacterisedVariableParseResultPostProcessor">
+      </class>
+   </extension>
 
 </plugin>

--- a/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/src/META-INF/services/de.uka.ipd.sdq.stoex.analyser.visitors.ITypeInference
+++ b/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/src/META-INF/services/de.uka.ipd.sdq.stoex.analyser.visitors.ITypeInference
@@ -1,0 +1,1 @@
+de.uka.ipd.sdq.pcm.stochasticexpressions.TypeInference

--- a/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/src/META-INF/services/org.palladiosimulator.commons.stoex.parser.ParseResultPostProcessor
+++ b/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/src/META-INF/services/org.palladiosimulator.commons.stoex.parser.ParseResultPostProcessor
@@ -1,0 +1,1 @@
+de.uka.ipd.sdq.pcm.stochasticexpressions.CharacterisedVariableParseResultPostProcessor

--- a/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/src/de/uka/ipd/sdq/pcm/stochasticexpressions/CharacterisedVariableParseResultPostProcessor.java
+++ b/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/src/de/uka/ipd/sdq/pcm/stochasticexpressions/CharacterisedVariableParseResultPostProcessor.java
@@ -1,0 +1,125 @@
+package de.uka.ipd.sdq.pcm.stochasticexpressions;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Optional;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.parser.IParseResult;
+import org.eclipse.xtext.parser.ParseResult;
+import org.palladiosimulator.commons.stoex.parser.ParseResultPostProcessor;
+import org.palladiosimulator.pcm.parameter.CharacterisedVariable;
+import org.palladiosimulator.pcm.parameter.ParameterFactory;
+import org.palladiosimulator.pcm.parameter.VariableCharacterisationType;
+
+import de.uka.ipd.sdq.stoex.Variable;
+import de.uka.ipd.sdq.stoex.VariableReference;
+
+/**
+ * Post processor for StoEx parse results that injects {@link CharacterisedVariable} instances into
+ * the result. These more specific variable types replace the generic {@link Variable} instances if
+ * the variable refers to a {@link VariableCharacterisationType}.
+ */
+public class CharacterisedVariableParseResultPostProcessor implements ParseResultPostProcessor {
+
+    @Override
+    public IParseResult postProcess(final IParseResult givenResult) {
+        var result = givenResult;
+        var variableReferences = findContentOfType(result.getRootASTElement(), VariableReference.class);
+        for (var variableReference : variableReferences) {
+            var refName = variableReference.getReferenceName();
+            var characterisationType = VariableCharacterisationType.get(refName);
+            if (characterisationType == null) {
+                // the reference does not refer to a characterisation type
+                continue;
+            }
+            var variable = findParent(variableReference, Variable.class);
+            if (variable.isEmpty()) {
+                // the reference does not belong to a variable
+                // this should not happen but might change in the future
+                continue;
+            }
+            result = replaceVariable(variable.get(), characterisationType, result);
+        }
+
+        return result;
+    }
+
+    /**
+     * Replaces a variable in the given {@link IParseResult}.
+     * 
+     * The result will be a new {@link IParseResult} instance if the variable to be replaced is the
+     * root element of the given result.
+     * 
+     * @param variable
+     *            The variable to replace.
+     * @param characterisationType
+     *            The characteristic variable type to use in the replacement.
+     * @param result
+     *            The result that contains the variable.
+     * @return The same or a new {@link IParseResult} instance that contains the replacement.
+     */
+    protected IParseResult replaceVariable(Variable variable, VariableCharacterisationType characterisationType,
+            IParseResult result) {
+        var characterisedVariable = ParameterFactory.eINSTANCE.createCharacterisedVariable();
+        characterisedVariable.setId_Variable(variable.getId_Variable());
+        characterisedVariable.setCharacterisationType(characterisationType);
+        if (result.getRootASTElement() == variable) {
+            return new ParseResult(characterisedVariable, result.getRootNode(), result.hasSyntaxErrors());
+        } else {
+            EcoreUtil.replace(variable, characterisedVariable);
+        }
+        return result;
+    }
+
+    /**
+     * Finds all transitive contents (including the given start element) of the requested type.
+     * 
+     * @param <T>
+     *            The type of requested contents.
+     * @param start
+     *            The element to start the search from.
+     * @param type
+     *            The type of the requested contents.
+     * @return The found elements.
+     */
+    @SuppressWarnings("unchecked")
+    protected static <T extends EObject> Iterable<T> findContentOfType(EObject start, Class<T> type) {
+        var result = new ArrayList<T>();
+
+        var queue = new LinkedList<EObject>();
+        queue.add(start);
+        while (!queue.isEmpty()) {
+            var current = queue.pop();
+            queue.addAll(current.eContents());
+            if (type.isInstance(current)) {
+                result.add((T) current);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Finds a transitive parent (including itself) of a given type.
+     * 
+     * @param <T>
+     *            The type of the parent.
+     * @param source
+     *            The element to start the search from.
+     * @param parentType
+     *            The type of the parent.
+     * @return The found parent or an empty result if there is no such parent.
+     */
+    @SuppressWarnings("unchecked")
+    protected static <T> Optional<T> findParent(EObject source, Class<T> parentType) {
+        for (EObject current = source; current != null; current = current.eContainer()) {
+            if (parentType.isInstance(current)) {
+                return Optional.of((T) current);
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/src/de/uka/ipd/sdq/pcm/stochasticexpressions/CharacterisedVariableParseResultPostProcessor.java
+++ b/bundles/de.uka.ipd.sdq.pcm.stochasticexpressions/src/de/uka/ipd/sdq/pcm/stochasticexpressions/CharacterisedVariableParseResultPostProcessor.java
@@ -92,6 +92,9 @@ public class CharacterisedVariableParseResultPostProcessor implements ParseResul
         queue.add(start);
         while (!queue.isEmpty()) {
             var current = queue.pop();
+            if (current == null) {
+                continue;
+            }
             queue.addAll(current.eContents());
             if (type.isInstance(current)) {
                 result.add((T) current);

--- a/bundles/org.palladiosimulator.pcm/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.pcm/META-INF/MANIFEST.MF
@@ -81,5 +81,6 @@ Require-Bundle: org.eclipse.core.runtime,
  de.uka.ipd.sdq.units;visibility:=reexport,
  de.uka.ipd.sdq.errorhandling,
  org.eclipse.ocl.ecore;bundle-version="1.2.1",
- org.palladiosimulator.pcm.workflow;resolution:=optional
+ org.palladiosimulator.pcm.workflow;resolution:=optional,
+ org.palladiosimulator.commons.stoex.api;bundle-version="4.3.0"
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.palladiosimulator.pcm/src/org/palladiosimulator/pcm/core/impl/PCMRandomVariableImpl.java
+++ b/bundles/org.palladiosimulator.pcm/src/org/palladiosimulator/pcm/core/impl/PCMRandomVariableImpl.java
@@ -1,25 +1,24 @@
 package org.palladiosimulator.pcm.core.impl;
 
-import org.antlr.runtime.ANTLRStringStream;
-import org.antlr.runtime.CommonTokenStream;
-import org.antlr.runtime.RecognitionException;
-import org.palladiosimulator.pcm.stochasticexpressions.parser.MyPCMStoExLexer;
-import org.palladiosimulator.pcm.stochasticexpressions.parser.MyPCMStoExParser;
+import org.palladiosimulator.commons.stoex.api.StoExParser;
+import org.palladiosimulator.commons.stoex.api.StoExParser.SyntaxErrorException;
 
 import de.uka.ipd.sdq.stoex.Expression;
 
 public class PCMRandomVariableImpl extends PCMRandomVariableImplGen {
 
     /**
+     * Instance of an {@link StoExParser} to parse textual StoEx expressions.
+     */
+    private static final StoExParser STOEX_PARSER = StoExParser.createInstance();
+
+    /**
      * Cached version of specification to decide if re-parsing is required.
-     *
-     * @generated NOT
      */
     private String lastParsedSpecification;
+
     /**
      * Cached version of parsed specification to return if no re-parsing is required.
-     *
-     * @generated NOT
      */
     private Expression lastParseExpression;
 
@@ -29,28 +28,20 @@ public class PCMRandomVariableImpl extends PCMRandomVariableImplGen {
      * stochastic expression language.
      *
      * @return The prepared Expression parsed from the specification string.
-     *
-     * @generated not
      */
     @Override
     public Expression basicGetExpression() {
         if (this.lastParseExpression == null || !this.lastParsedSpecification.equals(this.getSpecification())) {
             // re-parsing required
-            final MyPCMStoExLexer lexer = new MyPCMStoExLexer(new ANTLRStringStream(this.getSpecification()));
-            final MyPCMStoExParser parser = new MyPCMStoExParser(new CommonTokenStream(lexer));
+
             Expression e;
             try {
-                e = parser.expression();
-            } catch (final RecognitionException e1) {
-                e = null;
-            }
-            if (parser.hasErrors()) {
+                e = STOEX_PARSER.parse(this.getSpecification());
+            } catch (final SyntaxErrorException e1) {
                 e = null;
             }
             this.lastParseExpression = e;
             this.lastParsedSpecification = new String(this.getSpecification());
-        } else {
-            // old parsed result can be returned
         }
         return this.lastParseExpression;
     }

--- a/releng/org.palladiosimulator.pcm.targetplatform/org.palladiosimulator.pcm.targetplatform.target
+++ b/releng/org.palladiosimulator.pcm.targetplatform/org.palladiosimulator.pcm.targetplatform.target
@@ -81,5 +81,11 @@
 <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
 <repository location="http://download.eclipse.org/releases/2020-06/202006171000/"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+<unit id="org.mockito" version="2.23.0.v20200310-1642"/>
+<unit id="net.bytebuddy.byte-buddy" version="1.9.0.v20181107-1410"/>
+<unit id="org.objenesis" version="2.6.0.v20180420-1519"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/2020-06/"/>
+</location>
 </locations>
 </target>

--- a/releng/org.palladiosimulator.pcm.targetplatform/org.palladiosimulator.pcm.targetplatform.target
+++ b/releng/org.palladiosimulator.pcm.targetplatform/org.palladiosimulator.pcm.targetplatform.target
@@ -2,14 +2,14 @@
 <?pde version="3.8"?><target name="org.palladiosimulator.pcm Target Platform" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-<unit id="de.uka.ipd.sdq.stoex.feature.feature.group" version="2.2.0.201611171324"/>
+<unit id="org.palladiosimulator.commons.stoex.ui.feature.feature.group" version="0.0.0.0"/>
 <unit id="de.uka.ipd.sdq.errorhandling.feature.feature.group" version="2.2.0.201611171324"/>
 <unit id="de.uka.ipd.sdq.probfunction.math" version="2.0.2.201611171324"/>
 <unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="2.1.0.201611171324"/>
 <repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/releases/latest/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-<unit id="de.uka.ipd.sdq.stoex.feature.feature.group" version="2.2.0.201611171324"/>
+<unit id="org.palladiosimulator.commons.stoex.ui.feature.feature.group" version="0.0.0.0"/>
 <unit id="de.uka.ipd.sdq.errorhandling.feature.feature.group" version="2.2.0.201611171324"/>
 <unit id="de.uka.ipd.sdq.probfunction.math" version="2.0.2.201611171324"/>
 <unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="2.1.0.201611171324"/>
@@ -77,6 +77,8 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.13.0.202004160913"/>
+<unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
+<unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
 <repository location="http://download.eclipse.org/releases/2020-06/202006171000/"/>
 </location>
 </locations>

--- a/tests/de.uka.ipd.sdq.pcm.stochasticexpressions.tests/META-INF/MANIFEST.MF
+++ b/tests/de.uka.ipd.sdq.pcm.stochasticexpressions.tests/META-INF/MANIFEST.MF
@@ -11,7 +11,12 @@ Require-Bundle: org.eclipse.core.runtime,
  org.junit,
  org.palladiosimulator.pcm,
  org.palladiosimulator.commons.stoex.api;bundle-version="4.3.0",
- org.palladiosimulator.commons.stoex.ui;bundle-version="4.3.0"
+ org.palladiosimulator.commons.stoex.ui;bundle-version="4.3.0",
+ org.mockito;bundle-version="2.23.0",
+ net.bytebuddy.byte-buddy;bundle-version="1.9.0",
+ org.objenesis;bundle-version="2.6.0",
+ org.hamcrest.library;bundle-version="1.3.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: de.uka.ipd.sdq.pcm.stochasticexpressions.tests
+Import-Package: org.junit.jupiter.api;version="5.6.0"

--- a/tests/de.uka.ipd.sdq.pcm.stochasticexpressions.tests/META-INF/MANIFEST.MF
+++ b/tests/de.uka.ipd.sdq.pcm.stochasticexpressions.tests/META-INF/MANIFEST.MF
@@ -9,6 +9,9 @@ Require-Bundle: org.eclipse.core.runtime,
  de.uka.ipd.sdq.stoex,
  de.uka.ipd.sdq.stoex.analyser,
  org.junit,
- org.palladiosimulator.pcm
+ org.palladiosimulator.pcm,
+ org.palladiosimulator.commons.stoex.api;bundle-version="4.3.0",
+ org.palladiosimulator.commons.stoex.ui;bundle-version="4.3.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
+Automatic-Module-Name: de.uka.ipd.sdq.pcm.stochasticexpressions.tests

--- a/tests/de.uka.ipd.sdq.pcm.stochasticexpressions.tests/src/de/uka/ipd/sdq/pcm/stochasticexpressions/tests/CharacterisedVariableParseResultPostProcessorTest.java
+++ b/tests/de.uka.ipd.sdq.pcm.stochasticexpressions.tests/src/de/uka/ipd/sdq/pcm/stochasticexpressions/tests/CharacterisedVariableParseResultPostProcessorTest.java
@@ -1,0 +1,90 @@
+package de.uka.ipd.sdq.pcm.stochasticexpressions.tests;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.parser.IParseResult;
+import org.eclipse.xtext.parser.ParseResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.palladiosimulator.pcm.parameter.CharacterisedVariable;
+import org.palladiosimulator.pcm.parameter.VariableCharacterisationType;
+
+import de.uka.ipd.sdq.pcm.stochasticexpressions.CharacterisedVariableParseResultPostProcessor;
+import de.uka.ipd.sdq.stoex.Expression;
+import de.uka.ipd.sdq.stoex.ProductExpression;
+import de.uka.ipd.sdq.stoex.ProductOperations;
+import de.uka.ipd.sdq.stoex.StoexFactory;
+import de.uka.ipd.sdq.stoex.Variable;
+
+public class CharacterisedVariableParseResultPostProcessorTest {
+
+    private CharacterisedVariableParseResultPostProcessor subject;
+
+    @BeforeEach
+    public void setup() {
+        subject = new CharacterisedVariableParseResultPostProcessor();
+    }
+
+    @Test
+    public void testNoChanges() {
+        var simpleExpression = StoexFactory.eINSTANCE.createIntLiteral();
+        simpleExpression.setValue(1);
+        var expected = createResult(simpleExpression);
+        var actual = subject.postProcess(expected);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testChangedRootObject() {
+        var variable = createVariable("TYPE");
+        var input = createResult(variable);
+
+        var actual = subject.postProcess(input);
+
+        assertNotEquals(input, actual);
+        assertEquals(input.getRootNode(), actual.getRootNode());
+        assertEquals(input.hasSyntaxErrors(), actual.hasSyntaxErrors());
+        assertThat(actual.getRootASTElement(), is(instanceOf(CharacterisedVariable.class)));
+        var newVariable = (CharacterisedVariable) actual.getRootASTElement();
+        assertEquals(VariableCharacterisationType.TYPE, newVariable.getCharacterisationType());
+    }
+
+    @Test
+    public void testChangedNestedObject() {
+        var variable1 = createVariable("VALUE");
+        var variable2 = createVariable("test");
+        var product = StoexFactory.eINSTANCE.createProductExpression();
+        product.setLeft(variable1);
+        product.setRight(variable2);
+        product.setOperation(ProductOperations.MULT);
+        var input = createResult(product);
+
+        var actual = subject.postProcess(input);
+
+        assertEquals(input, actual);
+        assertThat(actual.getRootASTElement(), is(instanceOf(ProductExpression.class)));
+        var newProduct = (ProductExpression)actual.getRootASTElement();
+        assertThat(newProduct.getLeft(), is(instanceOf(CharacterisedVariable.class)));
+        var newVariable = (CharacterisedVariable)newProduct.getLeft();
+        assertEquals(VariableCharacterisationType.VALUE, newVariable.getCharacterisationType());
+    }
+
+    protected static IParseResult createResult(Expression rootObject) {
+        var rootNode = mock(ICompositeNode.class);
+        return new ParseResult(rootObject, rootNode, false);
+    }
+
+    protected static Variable createVariable(String name) {
+        var variable = StoexFactory.eINSTANCE.createVariable();
+        var reference = StoexFactory.eINSTANCE.createVariableReference();
+        reference.setReferenceName(name);
+        variable.setId_Variable(reference);
+        return variable;
+    }
+}

--- a/tests/de.uka.ipd.sdq.pcm.stochasticexpressions.tests/src/de/uka/ipd/sdq/pcm/stochasticexpressions/tests/TypeInferTests.java
+++ b/tests/de.uka.ipd.sdq.pcm.stochasticexpressions.tests/src/de/uka/ipd/sdq/pcm/stochasticexpressions/tests/TypeInferTests.java
@@ -1,21 +1,30 @@
 package de.uka.ipd.sdq.pcm.stochasticexpressions.tests;
 
-import org.antlr.runtime.ANTLRStringStream;
-import org.antlr.runtime.CommonTokenStream;
-import org.antlr.runtime.RecognitionException;
-import org.palladiosimulator.pcm.stochasticexpressions.parser.PCMStoExLexer;
-import org.palladiosimulator.pcm.stochasticexpressions.parser.PCMStoExParser;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.palladiosimulator.commons.stoex.api.StoExParser;
+import org.palladiosimulator.commons.stoex.api.StoExParser.SyntaxErrorException;
 
 import de.uka.ipd.sdq.stoex.Expression;
 import de.uka.ipd.sdq.stoex.FunctionLiteral;
 import de.uka.ipd.sdq.stoex.IfElseExpression;
 import de.uka.ipd.sdq.stoex.analyser.visitors.ExpressionInferTypeVisitor;
 import de.uka.ipd.sdq.stoex.analyser.visitors.TypeEnum;
-import junit.framework.TestCase;
 
-public class TypeInferTests extends TestCase {
+public class TypeInferTests {
+    
+    private static StoExParser stoexParser;
 
-	public void testEnums() throws RecognitionException{
+    @BeforeClass
+    public static void init() {
+        stoexParser = StoExParser.createInstance();
+    }
+    
+    @Test
+	public void testEnums() throws SyntaxErrorException{
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		Expression expression = parser("\"blah\"");
 		infer(expression,visitor);
@@ -26,29 +35,32 @@ public class TypeInferTests extends TestCase {
 		assertEquals(TypeEnum.ENUM_PMF, visitor.getType(expression));
 	}
 	
-	public void testIntPMF() throws RecognitionException{
+    @Test
+	public void testIntPMF() throws SyntaxErrorException{
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		Expression expression = parser("IntPMF[(1;0.2)(2;0.4)]");
 		infer(expression,visitor);
 		assertEquals(TypeEnum.INT_PMF, visitor.getType(expression));
 	}
 
-	public void testNegativeDoublePDF() throws RecognitionException{
+    @Test
+	public void testNegativeDoublePDF() throws SyntaxErrorException{
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		Expression expression = parser("DoublePDF[(-1.0;0.2)(2.0;0.4)]");
 		infer(expression,visitor);
 		assertEquals(TypeEnum.DOUBLE_PDF, visitor.getType(expression));
 	}
 
-	
-	public void testDoubleAnyCompare() throws RecognitionException{
+    @Test
+	public void testDoubleAnyCompare() throws SyntaxErrorException{
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		Expression expression = parser("192.0 / file.STRUCTURE < 1");
 		infer(expression,visitor);
 		assertEquals(TypeEnum.BOOL_PMF, visitor.getType(expression));
 	}
 
-	public void testDoubleAnyCompareIfElse() throws RecognitionException{
+    @Test
+	public void testDoubleAnyCompareIfElse() throws SyntaxErrorException{
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		IfElseExpression expression = (IfElseExpression) parser("192.0 / file.STRUCTURE < 1 ? 5 : 5");
 		infer(expression,visitor);
@@ -56,7 +68,8 @@ public class TypeInferTests extends TestCase {
 		assertEquals(TypeEnum.BOOL_PMF, visitor.getType(expression.getConditionExpression()));
 	}
 
-	public void testTypeInfererBool() throws RecognitionException {
+    @Test
+	public void testTypeInfererBool() throws SyntaxErrorException {
 		assertTrue(infer("true AND false") == TypeEnum.BOOL);
 		assertTrue(infer("true OR false") == TypeEnum.BOOL);
 		assertTrue(infer("128.0 < 192 OR false") == TypeEnum.BOOL);
@@ -64,7 +77,8 @@ public class TypeInferTests extends TestCase {
 		assertTrue(infer("true ? 1 : 5") == TypeEnum.ANY);
 	}
 	
-	public void testsubInfer() throws RecognitionException {
+    @Test
+	public void testsubInfer() throws SyntaxErrorException {
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		IfElseExpression expression = (IfElseExpression) parser("true ? 1 : 5.5");
 		infer(expression,visitor);
@@ -73,7 +87,8 @@ public class TypeInferTests extends TestCase {
 		assertEquals(TypeEnum.DOUBLE,visitor.getType(expression.getElseExpression()));
 	}
 
-	public void testSubFuncInfer() throws RecognitionException {
+    @Test
+	public void testSubFuncInfer() throws SyntaxErrorException {
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		FunctionLiteral expression = (FunctionLiteral) parser("Trunc(2.5)");
 		infer(expression,visitor);
@@ -81,49 +96,48 @@ public class TypeInferTests extends TestCase {
 		assertEquals(TypeEnum.DOUBLE,visitor.getType(expression.getParameters_FunctionLiteral().get(0)));
 	}	
 
-	public void testVariables() throws RecognitionException {
+    @Test
+	public void testVariables() throws SyntaxErrorException {
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		Expression expression = parser("file.TYPE");
 		infer(expression,visitor);
 		assertEquals(TypeEnum.ANY_PMF,visitor.getType(expression));
 	}
 
-	public void testParenthesis() throws RecognitionException {
+    @Test
+	public void testParenthesis() throws SyntaxErrorException {
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		Expression expression = parser("file.BYTESIZE * ( file.TYPE / 192 )");
 		infer(expression,visitor);
 		assertEquals(TypeEnum.ANY_PMF,visitor.getType(expression));
 	}
 	
-	public void testTenaryOp() throws RecognitionException {
+    @Test
+	public void testTenaryOp() throws SyntaxErrorException {
 		ExpressionInferTypeVisitor visitor = new ExpressionInferTypeVisitor();
 		IfElseExpression expression = (IfElseExpression) parser("file.TYPE > 192 ? file.BYTESIZE * ( file.TYPE / 192 ) : file.BYTESIZE");
 		infer(expression,visitor);
 	}
 	
-	private TypeEnum infer(String expression) throws RecognitionException{
+	private TypeEnum infer(String expression) throws SyntaxErrorException{
 		return infer(expression, new ExpressionInferTypeVisitor());
 	}
 	
-	private  TypeEnum infer(String expression, ExpressionInferTypeVisitor typeInferer) throws RecognitionException{
+	private  TypeEnum infer(String expression, ExpressionInferTypeVisitor typeInferer) throws SyntaxErrorException{
 		Expression formula = parser(expression);
 		typeInferer.doSwitch(formula);
 		
 		return typeInferer.getType(formula);
 	}
 
-	private  TypeEnum infer(Expression expression, ExpressionInferTypeVisitor typeInferer) throws RecognitionException{
+	private  TypeEnum infer(Expression expression, ExpressionInferTypeVisitor typeInferer) throws SyntaxErrorException{
 		Expression formula = expression;
 		typeInferer.doSwitch(formula);
 		
 		return typeInferer.getType(formula);
 	}
 	
-	private Expression parser(String expression) throws RecognitionException {
-		PCMStoExLexer lexer = new PCMStoExLexer(
-				new ANTLRStringStream(expression));
-		Expression formula = null;
-		formula = new PCMStoExParser(new CommonTokenStream(lexer)).expression();
-		return formula;
+	private Expression parser(String expression) throws SyntaxErrorException {
+		return stoexParser.parse(expression);
 	}
 }

--- a/tests/org.palladiosimulator.pcm.tests/META-INF/MANIFEST.MF
+++ b/tests/org.palladiosimulator.pcm.tests/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: tools.mdsd.library.standalone.initialization;bundle-version="0.1.0",
  org.hamcrest.core;bundle-version="1.3.0",
  org.hamcrest.library;bundle-version="1.3.0",
- org.palladiosimulator.commons.stoex.ui;bundle-version="4.3.0"
+ org.palladiosimulator.commons.stoex.ui;bundle-version="4.3.0",
+ de.uka.ipd.sdq.pcm.stochasticexpressions;bundle-version="4.3.0"
 Import-Package: org.junit;version="4.12.0",
  org.junit.jupiter.api;version="5.6.0"

--- a/tests/org.palladiosimulator.pcm.tests/META-INF/MANIFEST.MF
+++ b/tests/org.palladiosimulator.pcm.tests/META-INF/MANIFEST.MF
@@ -6,6 +6,9 @@ Bundle-Version: 4.3.0.qualifier
 Fragment-Host: org.palladiosimulator.pcm;bundle-version="4.3.0"
 Automatic-Module-Name: org.palladiosimulator.pcm.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: tools.mdsd.library.standalone.initialization;bundle-version="0.1.0"
+Require-Bundle: tools.mdsd.library.standalone.initialization;bundle-version="0.1.0",
+ org.hamcrest.core;bundle-version="1.3.0",
+ org.hamcrest.library;bundle-version="1.3.0",
+ org.palladiosimulator.commons.stoex.ui;bundle-version="4.3.0"
 Import-Package: org.junit;version="4.12.0",
  org.junit.jupiter.api;version="5.6.0"

--- a/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/core/impl/PCMRandomVariableTest.java
+++ b/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/core/impl/PCMRandomVariableTest.java
@@ -1,0 +1,33 @@
+package org.palladiosimulator.pcm.core.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import org.junit.jupiter.api.Test;
+import org.palladiosimulator.pcm.core.CoreFactory;
+import org.palladiosimulator.pcm.tests.impl.TestBase;
+
+import de.uka.ipd.sdq.stoex.IntLiteral;
+
+public class PCMRandomVariableTest extends TestBase {
+
+    @Test
+    public void testSuccessfullParsingOfValidExpression() {
+        var variable = CoreFactory.eINSTANCE.createPCMRandomVariable();
+        variable.setSpecification("1");
+        var parsedExpression = variable.getExpression();
+        assertThat(parsedExpression, is(instanceOf(IntLiteral.class)));
+        assertThat(((IntLiteral) parsedExpression).getValue(), is(1));
+    }
+
+    @Test
+    public void testReturnNullOnInvalidExpression() {
+        var variable = CoreFactory.eINSTANCE.createPCMRandomVariable();
+        variable.setSpecification("1+");
+        var parsedExpression = variable.getExpression();
+        assertThat(parsedExpression, is(nullValue()));
+    }
+
+}

--- a/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/impl/ConstraintTestBase.java
+++ b/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/impl/ConstraintTestBase.java
@@ -3,54 +3,13 @@ package org.palladiosimulator.pcm.tests.impl;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.Optional;
 
 import org.eclipse.emf.common.util.Diagnostic;
-import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.Diagnostician;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 
-import tools.mdsd.library.standalone.initialization.StandaloneInitializationException;
-import tools.mdsd.library.standalone.initialization.StandaloneInitializerBuilder;
-
-public abstract class ConstraintTestBase {
-
-    private static final String PROJECT_NAME_TEST = "org.palladiosimulator.pcm.tests";
-    private ResourceSetImpl rs;
-
-    @BeforeAll
-    public static void init() throws StandaloneInitializationException {
-        StandaloneInitializerBuilder.builder()
-            .registerProjectURI(ConstraintTestBase.class, PROJECT_NAME_TEST)
-            .build()
-            .init();
-    }
-
-    @BeforeEach
-    public void setup() {
-        rs = new ResourceSetImpl();
-    }
-
-    public <T extends EObject> T loadModel(String path, Class<T> rootElementType) {
-        return Optional.ofNullable(rs.getResource(createURIFromRelativePath(path), true))
-            .map(Resource::getContents)
-            .map(Collection::iterator)
-            .map(Iterator::next)
-            .filter(rootElementType::isInstance)
-            .map(rootElementType::cast)
-            .orElseThrow(() -> new IllegalArgumentException());
-    }
-
-    protected static URI createURIFromRelativePath(String path) {
-        return URI.createPlatformPluginURI(String.format("%s/%s", PROJECT_NAME_TEST, path), false);
-    }
+public abstract class ConstraintTestBase extends TestBase {
 
     protected static void assertViolation(EObject object) {
         assertViolation(object, null);

--- a/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/impl/TestBase.java
+++ b/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/impl/TestBase.java
@@ -1,0 +1,49 @@
+package org.palladiosimulator.pcm.tests.impl;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import tools.mdsd.library.standalone.initialization.StandaloneInitializationException;
+import tools.mdsd.library.standalone.initialization.StandaloneInitializerBuilder;
+
+public class TestBase {
+
+    private static final String PROJECT_NAME_TEST = "org.palladiosimulator.pcm.tests";
+    private ResourceSetImpl rs;
+
+    @BeforeAll
+    public static void init() throws StandaloneInitializationException {
+        StandaloneInitializerBuilder.builder()
+            .registerProjectURI(ConstraintTestBase.class, PROJECT_NAME_TEST)
+            .build()
+            .init();
+    }
+
+    @BeforeEach
+    public void setup() {
+        rs = new ResourceSetImpl();
+    }
+
+    public <T extends EObject> T loadModel(String path, Class<T> rootElementType) {
+        return Optional.ofNullable(rs.getResource(createURIFromRelativePath(path), true))
+            .map(Resource::getContents)
+            .map(Collection::iterator)
+            .map(Iterator::next)
+            .filter(rootElementType::isInstance)
+            .map(rootElementType::cast)
+            .orElseThrow(() -> new IllegalArgumentException());
+    }
+
+    protected static URI createURIFromRelativePath(String path) {
+        return URI.createPlatformPluginURI(String.format("%s/%s", PROJECT_NAME_TEST, path), false);
+    }
+
+}


### PR DESCRIPTION
This PR addresses [PALLADIO-498](https://jira.palladio-simulator.com/browse/PALLADIO-498) and [COMMONS-33](https://jira.palladio-simulator.com/browse/COMMONS-33). Both issues are closely connected, so it is useful to handle them in the same pull request.

The majority of the PR replaces the old StoEx parser with the new Xtext-based one. The second part provides a post processor for parsing results that injects CharacterisedVariable instances into the parsing result.

Because of the tight coupling of this PR and PalladioSimulator/Palladio-Core-Commons#15, this PR should be merged as soon as possible after the other one.