### PR TITLE
Switch to 2020-12

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,11 +3,11 @@
 	<extension>
 		<groupId>org.eclipse.tycho.extras</groupId>
 		<artifactId>tycho-pomless</artifactId>
-		<version>1.7.0</version>
+		<version>2.1.0</version>
 	</extension>
 	<extension>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.5</version>
+		<version>0.2.6</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.5.1</version>
+		<version>0.7.1</version>
 	</parent>
 	<groupId>org.palladiosimulator.pcm</groupId>
 	<artifactId>parent</artifactId>	

--- a/releng/org.palladiosimulator.pcm.targetplatform/org.palladiosimulator.pcm.targetplatform.target
+++ b/releng/org.palladiosimulator.pcm.targetplatform/org.palladiosimulator.pcm.targetplatform.target
@@ -63,13 +63,9 @@
 <unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="1.0.1.201609191729"/>
 <repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/nightly/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="tbd"/>
-<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases/latest/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="tbd"/>
-<repository location="https://updatesite.mdsd.tools/ecore-workflow/nightly/"/>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+<unit id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature.feature.group" version="0.0.0"/>
+<repository location="https://updatesite.mdsd.tools/ecore-workflow/releases/0.3.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="0.1.0.202004172117"/>
@@ -79,13 +75,13 @@
 <unit id="org.eclipse.gmf.runtime.notation.feature.group" version="1.13.0.202004160913"/>
 <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
 <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
-<repository location="http://download.eclipse.org/releases/2020-06/202006171000/"/>
+<repository location="http://download.eclipse.org/releases/2020-12/202012161000/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.mockito" version="2.23.0.v20200310-1642"/>
 <unit id="net.bytebuddy.byte-buddy" version="1.9.0.v20181107-1410"/>
 <unit id="org.objenesis" version="2.6.0.v20180420-1519"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/2020-06/"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/2020-12/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
Fixes build errors because of recent changes of EcoreWorkflow (introduces dependency to 2020-12).