### PR TITLE
PALLADIO-146 Enforce "exactlyOnce" part of constraint

### DIFF
--- a/bundles/org.palladiosimulator.pcm/src/org/palladiosimulator/pcm/allocation/impl/AllocationImpl.java
+++ b/bundles/org.palladiosimulator.pcm/src/org/palladiosimulator/pcm/allocation/impl/AllocationImpl.java
@@ -1,5 +1,6 @@
 package org.palladiosimulator.pcm.allocation.impl;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
@@ -41,6 +42,10 @@ public class AllocationImpl extends AllocationImplGen {
      * @return True if the allocation is correct, False otherwise.
      */
     protected boolean validateEachAssemblyContextWithinSystemHasToBeAllocatedExactlyOnce() {
+        if (moreThanOneAllocationForAssemblyContextExists()) {
+            // assembly context allocated more than one time
+            return false;
+        }
         var allocatedAssemblyContexts = getAllocatedAssemblyContexts();
         var unallocatedAssemblyContexts = findUnallocatedAssemblyContexts(allocatedAssemblyContexts);
 
@@ -51,6 +56,21 @@ public class AllocationImpl extends AllocationImplGen {
         }
 
         return testCorrectAllocationOfSubsystems(remainingSubsystems, allocatedAssemblyContexts);
+    }
+
+    /**
+     * Determines if one assembly context has been allocated more than once.
+     * 
+     * @return True if an assembly context has been allocated more than once, false otherwise.
+     */
+    protected boolean moreThanOneAllocationForAssemblyContextExists() {
+        var allocatedAssemblyContexts = new HashSet<>();
+        for (var allocation : getAllocationContexts_Allocation()) {
+            if (!allocatedAssemblyContexts.add(allocation.getAllocation_AllocationContext())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/AllocationConstraintTest.java
+++ b/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/AllocationConstraintTest.java
@@ -24,7 +24,7 @@ public class AllocationConstraintTest extends ConstraintTestBase {
          */
         var allocation = loadModel("testmodels/Subsystem_Test/allocateSubSystemDirectly.allocation",
                 Allocation.class);
-        assertNoViolation(allocation);
+        assertViolation(allocation);
     }
         
     @Test

--- a/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/AllocationConstraintTest.java
+++ b/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/AllocationConstraintTest.java
@@ -91,4 +91,15 @@ public class AllocationConstraintTest extends ConstraintTestBase {
         assertViolation(allocation);
     }
     
+    @Test
+    public void testSubsystem_MissingComponentAllocation() {
+        /*
+         * System consists of subsystem and component
+         * Allocation allocates the subsystem
+         */
+        var allocation = loadModel("testmodels/Subsystem_Test/subsystemAndComponent_missingComponent.allocation",
+                Allocation.class);
+        assertViolation(allocation);
+    }
+    
 }

--- a/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/subsystemAndComponent.system
+++ b/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/subsystemAndComponent.system
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="ASCII"?>
+<system:System xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:subsystem="http://palladiosimulator.org/PalladioComponentModel/SubSystem/5.2" xmlns:system="http://palladiosimulator.org/PalladioComponentModel/System/5.2" id="_vpZ-wFTAEeuTDcSKnPVTOQ" entityName="New System">
+  <assemblyContexts__ComposedStructure id="_0iFk8FTAEeuTDcSKnPVTOQ" entityName="Assembly_AComponent">
+    <encapsulatedComponent__AssemblyContext xsi:type="repository:BasicComponent" href="default.repository#_os1t4CHbEd62GabW1zGSBw"/>
+  </assemblyContexts__ComposedStructure>
+  <assemblyContexts__ComposedStructure id="_1ID_0FTAEeuTDcSKnPVTOQ" entityName="Assembly_ASubsystem">
+    <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+  </assemblyContexts__ComposedStructure>
+  <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_3h4W4FTAEeuTDcSKnPVTOQ" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_0Eg4IFTAEeuTDcSKnPVTOQ" assemblyContext_ProvidedDelegationConnector="_1ID_0FTAEeuTDcSKnPVTOQ">
+    <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+  </connectors__ComposedStructure>
+  <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_33okcFTAEeuTDcSKnPVTOQ" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_zdGS0FTAEeuTDcSKnPVTOQ" assemblyContext_ProvidedDelegationConnector="_0iFk8FTAEeuTDcSKnPVTOQ">
+    <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_qZKs0CHbEd62GabW1zGSBw"/>
+  </connectors__ComposedStructure>
+  <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_zdGS0FTAEeuTDcSKnPVTOQ" entityName="AnInterfaceProvidedRole">
+    <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+  </providedRoles_InterfaceProvidingEntity>
+  <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_0Eg4IFTAEeuTDcSKnPVTOQ" entityName="AnInterfaceProvidedRole1">
+    <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+  </providedRoles_InterfaceProvidingEntity>
+</system:System>

--- a/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/subsystemAndComponent_missingComponent.allocation
+++ b/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/subsystemAndComponent_missingComponent.allocation
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ASCII"?>
+<allocation:Allocation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:allocation="http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2" id="_6g7h8FTAEeuTDcSKnPVTOQ" entityName="New Allocation">
+  <targetResourceEnvironment_Allocation href="My.resourceenvironment#/"/>
+  <system_Allocation href="subsystemAndComponent.system#_vpZ-wFTAEeuTDcSKnPVTOQ"/>
+  <allocationContexts_Allocation id="_FbzUEFTBEeuTDcSKnPVTOQ" entityName="Allocation_Assembly_ASubsystem">
+    <resourceContainer_AllocationContext href="My.resourceenvironment#_6pA4ICqnEeCY1crWOpT1yA"/>
+    <assemblyContext_AllocationContext href="subsystemAndComponent.system#_1ID_0FTAEeuTDcSKnPVTOQ"/>
+  </allocationContexts_Allocation>
+</allocation:Allocation>


### PR DESCRIPTION
In the previous pull request #16, we have overseen that the enforcement of "exactlyOnce" was missing. Therefore, it was possible to allocate the same assembly context multiple times. This is not an issue specific for sub systems but a general issue.

I reopened the issue [PALLADIO-146](https://palladio-simulator.atlassian.net/browse/PALLADIO-146) to fix this problem.