### PR TITLE
PALLADIO-522 Constraint to avoid multiple instances of same subsystem

### DIFF
--- a/bundles/org.palladiosimulator.pcm/model/pcm.ecore
+++ b/bundles/org.palladiosimulator.pcm/model/pcm.ecore
@@ -187,6 +187,22 @@
           <details key="multipleConnectorsConstraint" value="self.connectors__ComposedStructure->select(conn | conn.oclIsTypeOf(pcm::core::composition::ProvidedDelegationConnector)).oclAsType(pcm::core::composition::ProvidedDelegationConnector)->forAll( c1, c2 | c1 &lt;> c2 implies c1.outerProvidedRole_ProvidedDelegationConnector &lt;> c2.outerProvidedRole_ProvidedDelegationConnector)&#xD;&#xA;"/>
           <details key="multipleConnectorsConstraintForAssemblyConnectors" value="self.connectors__ComposedStructure->select(conn | conn.oclIsTypeOf(pcm::core::composition::AssemblyConnector)).oclAsType(AssemblyConnector)->forAll( c1, c2 | ( (c1 &lt;> c2) and ( c1.requiringAssemblyContext_AssemblyConnector = c2.requiringAssemblyContext_AssemblyConnector ) ) implies c1.requiredRole_AssemblyConnector &lt;> c2.requiredRole_AssemblyConnector )&#xD;&#xA;"/>
         </eAnnotations>
+        <eOperations name="validateSameSubsystemMustNotBeInstantiatedMoreThanOnce"
+            eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean">
+          <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
+            <details key="invariant" value="true"/>
+          </eAnnotations>
+          <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+            <details key="body" value="var validationSucceeded = org.palladiosimulator.pcm.core.composition.impl.ComposedStructureValidationUtil.validateSameSubsystemMustNotBeInstantiatedMoreThanOnce(this);&#xA;if (!validationSucceeded &amp;&amp; diagnostics != null) {&#xA;    diagnostics.add&#xA;        (new org.eclipse.emf.common.util.BasicDiagnostic&#xA;            (org.eclipse.emf.common.util.Diagnostic.ERROR,&#xA;                org.palladiosimulator.pcm.core.composition.util.CompositionValidator.DIAGNOSTIC_SOURCE,&#xA;                org.palladiosimulator.pcm.core.composition.util.CompositionValidator.COMPOSED_STRUCTURE__VALIDATE_SAME_SUBSYSTEM_MUST_NOT_BE_INSTANTIATED_MORE_THAN_ONCE,&#xA;                org.eclipse.emf.ecore.plugin.EcorePlugin.INSTANCE.getString(&quot;_UI_GenericConstraint_diagnostic&quot;, new Object[] { &quot;sameSubsystemMustNotBeInstantiatedMoreThanOnce&quot;, org.eclipse.emf.ecore.util.EObjectValidator.getObjectLabel(this, context) }),&#xA;                new Object [] { this }));&#xA;}&#xA;return validationSucceeded;"/>
+          </eAnnotations>
+          <eParameters name="diagnostics" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDiagnosticChain"/>
+          <eParameters name="context" lowerBound="1">
+            <eGenericType eClassifier="ecore:EDataType platform:/plugin/org.eclipse.emf.ecore/model/Ecore.ecore#//EMap">
+              <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+              <eTypeArguments eClassifier="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
+            </eGenericType>
+          </eParameters>
+        </eOperations>
         <eStructuralFeatures xsi:type="ecore:EReference" name="assemblyContexts__ComposedStructure"
             ordered="false" upperBound="-1" eType="#//core/composition/AssemblyContext"
             containment="true" eOpposite="#//core/composition/AssemblyContext/parentStructure__AssemblyContext"/>

--- a/bundles/org.palladiosimulator.pcm/src/org/palladiosimulator/pcm/core/composition/impl/ComposedStructureValidationUtil.java
+++ b/bundles/org.palladiosimulator.pcm/src/org/palladiosimulator/pcm/core/composition/impl/ComposedStructureValidationUtil.java
@@ -1,0 +1,110 @@
+package org.palladiosimulator.pcm.core.composition.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
+import org.palladiosimulator.pcm.core.composition.ComposedStructure;
+import org.palladiosimulator.pcm.subsystem.SubSystem;
+
+/**
+ * Utility class for validating invariants implemented in Java for the composition package.
+ * 
+ * The reason for this class is to reduce the amount of code that has to be placed within GenModel
+ * annotations as much as possible.
+ */
+public final class ComposedStructureValidationUtil {
+
+    private ComposedStructureValidationUtil() {
+        // intentionally left blank
+    }
+
+    /**
+     * Validates the constraint "sameSubsystemMustNotBeInstantiatedMoreThanOnce" on the given composed structure.
+     * @param composedStructure The entity to execute the validation on.
+     * @return True if no violation could be detected, false otherwise.
+     */
+    public static boolean validateSameSubsystemMustNotBeInstantiatedMoreThanOnce(ComposedStructure composedStructure) {
+        try {
+            return !isSameSubsystemInstantiatedMoreThanOnce(composedStructure);            
+        } catch (IllegalStateException e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return True if the same subsystem is instantiated more than once, false otherwise.
+     */
+    private static boolean isSameSubsystemInstantiatedMoreThanOnce(ComposedStructure composedStructure) {
+        var instantiatedSubsystems = getInstantiatedSubsystems(composedStructure);
+        var uniqueInstantiatedSubsystems = new HashSet<>(instantiatedSubsystems);
+        return instantiatedSubsystems.size() != uniqueInstantiatedSubsystems.size();
+    }
+
+    /**
+     * Collects all transitively instantiated subsystems within this composed structure.
+     * 
+     * @return A list of instantiated subsystems. The list might contain duplicates if the component
+     *         has been instantiated more than once.
+     */
+    private static Collection<SubSystem> getInstantiatedSubsystems(ComposedStructure composedStructure) {
+        Collection<AssemblyContext> assemblyContexts = getContainedAssemblyContexts(composedStructure,
+                Collections.emptySet());
+        return assemblyContexts.stream()
+            .map(AssemblyContext::getEncapsulatedComponent__AssemblyContext)
+            .filter(SubSystem.class::isInstance)
+            .map(SubSystem.class::cast)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Recursively collects all assembly contexts of the given composed structure.
+     * 
+     * @param composedStructure
+     *            The composed structure to start the search with.
+     * @param visitedComponents
+     *            The components that already have been visited during the recursion.
+     * @return A collection of all transitive assembly contexts (might contain duplicates).
+     */
+    private static Collection<AssemblyContext> getContainedAssemblyContexts(ComposedStructure composedStructure,
+            Set<ComposedStructure> visitedComponents) {
+        var result = new ArrayList<AssemblyContext>();
+        if (visitedComponents.contains(composedStructure)) {
+            throw new IllegalStateException("There is a cyclic instantiation!");
+        }
+        var newVisitedComponents = new HashSet<>(visitedComponents);
+        newVisitedComponents.add(composedStructure);
+        for (var containedAc : composedStructure.getAssemblyContexts__ComposedStructure()) {
+            result.add(containedAc);
+            result.addAll(getContainedAssemblyContexts(containedAc, newVisitedComponents));
+        }
+        return result;
+    }
+
+    /**
+     * Recursively collects all assembly contexts instantiated within the given assembly context.
+     * The result will not contain the given assembly context.
+     * 
+     * If the assembly context does not instantiate a composed structure, this method will return en
+     * empty collection.
+     * 
+     * @param ac
+     *            The assembly context to start the search with.
+     * @param visitedComponents
+     *            The components that already have been visited during the recursion.
+     * @return A collection of all transitive assembly contexts (might contain duplicates).
+     */
+    private static Collection<AssemblyContext> getContainedAssemblyContexts(AssemblyContext ac,
+            Set<ComposedStructure> visitedComponents) {
+        var component = ac.getEncapsulatedComponent__AssemblyContext();
+        if (component instanceof ComposedStructure) {
+            return getContainedAssemblyContexts((ComposedStructure) component, visitedComponents);
+        }
+        return Collections.emptyList();
+    }
+
+}

--- a/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/ComposedStructureTest.java
+++ b/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/tests/ComposedStructureTest.java
@@ -1,0 +1,109 @@
+package org.palladiosimulator.pcm.tests;
+
+import java.util.function.Function;
+
+import org.eclipse.emf.ecore.EObject;
+import org.junit.jupiter.api.Test;
+import org.palladiosimulator.pcm.core.composition.ComposedStructure;
+import org.palladiosimulator.pcm.tests.impl.ConstraintTestBase;
+
+public class ComposedStructureTest extends ConstraintTestBase {
+
+    @Test
+    public void testSystemNoViolation() {
+        /**
+         * System consists of only one assembly. Assembly instantiates a subsystem.
+         */
+        testSameSubsystemMustNotBeInstantiatedTwice("testmodels/Subsystem_Test/default.system", true,
+                org.palladiosimulator.pcm.system.System.class::cast);
+    }
+
+    @Test
+    public void testSystemViolationDirectlyInstantiated() {
+        /**
+         * System consists of two assemblies. Both assemblies instantiate the same subsystem ->
+         * violation.
+         */
+        testSameSubsystemMustNotBeInstantiatedTwice("testmodels/Subsystem_Test/twoInstancesOfSameSubsystem.system",
+                false, org.palladiosimulator.pcm.system.System.class::cast);
+    }
+
+    @Test
+    public void testSystemViolationTransitivelyInstantiated() {
+        /**
+         * System consists of two assemblies. First assembly instantiates a subsystem, second
+         * assembly instantiates another subsystem. First subsystem is instantiated within second
+         * subsystem -> violation.
+         */
+        testSameSubsystemMustNotBeInstantiatedTwice(
+                "testmodels/Subsystem_Test/twoInstancesOfSameSubsystemTransitively.system", false,
+                org.palladiosimulator.pcm.system.System.class::cast);
+    }
+
+    @Test
+    public void testCompositeViolationDirectlyInstantiated() {
+        /**
+         * Composite component consists of two assemblies. Both assemblies instantiate the same
+         * subsystem -> violation.
+         */
+        testSameSubsystemMustNotBeInstantiatedTwice("testmodels/Subsystem_Test/subsystemInstantiation.repository",
+                false, root -> findInRepoByName(root, "CompositeDirectViolation"));
+    }
+
+    @Test
+    public void testCompositeViolationTransitivelyInstantiated() {
+        /**
+         * Composite component consists of two assemblies. First assembly instantiates a subsystem,
+         * second assembly instantiates another subsystem. First subsystem is instantiated within
+         * second subsystem -> violation.
+         */
+        testSameSubsystemMustNotBeInstantiatedTwice("testmodels/Subsystem_Test/subsystemInstantiation.repository",
+                false, root -> findInRepoByName(root, "CompositeNestedViolation"));
+    }
+
+    @Test
+    public void testSubsystemViolationDirectlyInstantiated() {
+        /**
+         * Subsystem consists of two assemblies. Both assemblies instantiate the same subsystem ->
+         * violation.
+         */
+        testSameSubsystemMustNotBeInstantiatedTwice("testmodels/Subsystem_Test/subsystemInstantiation.repository",
+                false, root -> findInRepoByName(root, "SubsystemDirectViolation"));
+    }
+
+    @Test
+    public void testSubsystemViolationTransitivelyInstantiated() {
+        /**
+         * Subsystem consists of two assemblies. First assembly instantiates a subsystem, second
+         * assembly instantiates another subsystem. First subsystem is instantiated within second
+         * subsystem -> violation.
+         */
+        testSameSubsystemMustNotBeInstantiatedTwice("testmodels/Subsystem_Test/subsystemInstantiation.repository",
+                false, root -> findInRepoByName(root, "SubsystemNestedViolation"));
+    }
+
+    protected ComposedStructure findInRepoByName(EObject root, String name) {
+        for (var iter = root.eAllContents(); iter.hasNext();) {
+            var content = iter.next();
+            if (content instanceof ComposedStructure) {
+                var composite = (ComposedStructure) content;
+                if (name.equals(composite.getEntityName())) {
+                    return composite;
+                }
+            }
+        }
+        return null;
+    }
+
+    protected void testSameSubsystemMustNotBeInstantiatedTwice(String modelName, boolean expectSuccess,
+            Function<EObject, ComposedStructure> validationTargetSelector) {
+        var root = loadModel(modelName, EObject.class);
+        var composite = validationTargetSelector.apply(root);
+        if (expectSuccess) {
+            assertNoViolation(composite, "sameSubsystemMustNotBeInstantiatedMoreThanOnce");
+        } else {
+            assertViolation(composite, "sameSubsystemMustNotBeInstantiatedMoreThanOnce");
+        }
+    }
+
+}

--- a/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/subsystemInstantiation.repository
+++ b/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/subsystemInstantiation.repository
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="ASCII"?>
+<repository:Repository xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:subsystem="http://palladiosimulator.org/PalladioComponentModel/SubSystem/5.2" id="_cdtO0FdFEeuaCMRAtoxVYg" entityName="New Repository">
+  <components__Repository xsi:type="repository:CompositeComponent" id="_t6bkYFdFEeuaCMRAtoxVYg" entityName="CompositeDirectViolation">
+    <assemblyContexts__ComposedStructure id="_5xf5AFdFEeuaCMRAtoxVYg" entityName="Assembly_ASubsystem">
+      <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+    </assemblyContexts__ComposedStructure>
+    <assemblyContexts__ComposedStructure id="_6lvZYFdFEeuaCMRAtoxVYg" entityName="Assembly_ASubsystem">
+      <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+    </assemblyContexts__ComposedStructure>
+    <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_9H4mAFdFEeuaCMRAtoxVYg" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_8FkNYFdFEeuaCMRAtoxVYg" assemblyContext_ProvidedDelegationConnector="_6lvZYFdFEeuaCMRAtoxVYg">
+      <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+    </connectors__ComposedStructure>
+    <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_9fspEFdFEeuaCMRAtoxVYg" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_2AjW8FdFEeuaCMRAtoxVYg" assemblyContext_ProvidedDelegationConnector="_5xf5AFdFEeuaCMRAtoxVYg">
+      <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+    </connectors__ComposedStructure>
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_2AjW8FdFEeuaCMRAtoxVYg" entityName="provided">
+      <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+    </providedRoles_InterfaceProvidingEntity>
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_8FkNYFdFEeuaCMRAtoxVYg" entityName="AnInterface">
+      <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+    </providedRoles_InterfaceProvidingEntity>
+  </components__Repository>
+  <components__Repository xsi:type="repository:CompositeComponent" id="_-Pg8cFdFEeuaCMRAtoxVYg" entityName="CompositeNestedViolation">
+    <assemblyContexts__ComposedStructure id="_AxcGoFdGEeuaCMRAtoxVYg" entityName="Assembly_ANestedSubsystem">
+      <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_uJ2_0H2nEd6u9Md61yj-5Q"/>
+    </assemblyContexts__ComposedStructure>
+    <assemblyContexts__ComposedStructure id="_BMpb8FdGEeuaCMRAtoxVYg" entityName="Assembly_ASubsystem">
+      <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+    </assemblyContexts__ComposedStructure>
+    <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_CABZoFdGEeuaCMRAtoxVYg" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="__9gvUFdFEeuaCMRAtoxVYg" assemblyContext_ProvidedDelegationConnector="_AxcGoFdGEeuaCMRAtoxVYg">
+      <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_wFp-IH2nEd6u9Md61yj-5Q"/>
+    </connectors__ComposedStructure>
+    <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_CcRQwFdGEeuaCMRAtoxVYg" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_AXPd8FdGEeuaCMRAtoxVYg" assemblyContext_ProvidedDelegationConnector="_BMpb8FdGEeuaCMRAtoxVYg">
+      <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+    </connectors__ComposedStructure>
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="__9gvUFdFEeuaCMRAtoxVYg" entityName="AnInterface">
+      <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+    </providedRoles_InterfaceProvidingEntity>
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_AXPd8FdGEeuaCMRAtoxVYg" entityName="AnInterface">
+      <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+    </providedRoles_InterfaceProvidingEntity>
+  </components__Repository>
+  <components__Repository xsi:type="subsystem:SubSystem" id="_DmjSkFdGEeuaCMRAtoxVYg" entityName="SubsystemDirectViolation">
+    <assemblyContexts__ComposedStructure id="_HKsuwFdGEeuaCMRAtoxVYg" entityName="Assembly_ASubsystem">
+      <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+    </assemblyContexts__ComposedStructure>
+    <assemblyContexts__ComposedStructure id="_HsAFAFdGEeuaCMRAtoxVYg" entityName="Assembly_ASubsystem">
+      <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+    </assemblyContexts__ComposedStructure>
+    <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_IQ7XAFdGEeuaCMRAtoxVYg" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_G0QksFdGEeuaCMRAtoxVYg" assemblyContext_ProvidedDelegationConnector="_HsAFAFdGEeuaCMRAtoxVYg">
+      <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+    </connectors__ComposedStructure>
+    <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_Inom0FdGEeuaCMRAtoxVYg" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_GcqkEFdGEeuaCMRAtoxVYg" assemblyContext_ProvidedDelegationConnector="_HKsuwFdGEeuaCMRAtoxVYg">
+      <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+    </connectors__ComposedStructure>
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_GcqkEFdGEeuaCMRAtoxVYg" entityName="AnInterface">
+      <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+    </providedRoles_InterfaceProvidingEntity>
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_G0QksFdGEeuaCMRAtoxVYg" entityName="AnInterface">
+      <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+    </providedRoles_InterfaceProvidingEntity>
+  </components__Repository>
+  <components__Repository xsi:type="subsystem:SubSystem" id="_EzvecFdGEeuaCMRAtoxVYg" entityName="SubsystemNestedViolation">
+    <assemblyContexts__ComposedStructure id="_KSZfgFdGEeuaCMRAtoxVYg" entityName="Assembly_ANestedSubsystem">
+      <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_uJ2_0H2nEd6u9Md61yj-5Q"/>
+    </assemblyContexts__ComposedStructure>
+    <assemblyContexts__ComposedStructure id="_K2BxAFdGEeuaCMRAtoxVYg" entityName="Assembly_ASubsystem">
+      <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+    </assemblyContexts__ComposedStructure>
+    <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_LenbAFdGEeuaCMRAtoxVYg" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_JihhwFdGEeuaCMRAtoxVYg" assemblyContext_ProvidedDelegationConnector="_KSZfgFdGEeuaCMRAtoxVYg">
+      <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_wFp-IH2nEd6u9Md61yj-5Q"/>
+    </connectors__ComposedStructure>
+    <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_L2lPEFdGEeuaCMRAtoxVYg" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_J6tYQFdGEeuaCMRAtoxVYg" assemblyContext_ProvidedDelegationConnector="_K2BxAFdGEeuaCMRAtoxVYg">
+      <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+    </connectors__ComposedStructure>
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_JihhwFdGEeuaCMRAtoxVYg" entityName="AnInterface">
+      <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+    </providedRoles_InterfaceProvidingEntity>
+    <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_J6tYQFdGEeuaCMRAtoxVYg" entityName="AnInterface">
+      <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+    </providedRoles_InterfaceProvidingEntity>
+  </components__Repository>
+</repository:Repository>

--- a/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/twoInstancesOfSameSubsystem.system
+++ b/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/twoInstancesOfSameSubsystem.system
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="ASCII"?>
+<system:System xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:subsystem="http://palladiosimulator.org/PalladioComponentModel/SubSystem/5.2" xmlns:system="http://palladiosimulator.org/PalladioComponentModel/System/5.2" id="_MeT7QFc3EeuCksbjIpnqmw" entityName="New System">
+  <assemblyContexts__ComposedStructure id="_RvQQcFc3EeuCksbjIpnqmw" entityName="Assembly_ASubsystem">
+    <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+  </assemblyContexts__ComposedStructure>
+  <assemblyContexts__ComposedStructure id="_S6Ym0Fc3EeuCksbjIpnqmw" entityName="Assembly_ASubsystem">
+    <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+  </assemblyContexts__ComposedStructure>
+  <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_Vw-ZcFc3EeuCksbjIpnqmw" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_VHeJcFc3EeuCksbjIpnqmw" assemblyContext_ProvidedDelegationConnector="_S6Ym0Fc3EeuCksbjIpnqmw">
+    <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+  </connectors__ComposedStructure>
+  <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_WKd3gFc3EeuCksbjIpnqmw" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_UhS6QFc3EeuCksbjIpnqmw" assemblyContext_ProvidedDelegationConnector="_RvQQcFc3EeuCksbjIpnqmw">
+    <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+  </connectors__ComposedStructure>
+  <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_UhS6QFc3EeuCksbjIpnqmw" entityName="AnInterfaceProvidedRole">
+    <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+  </providedRoles_InterfaceProvidingEntity>
+  <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_VHeJcFc3EeuCksbjIpnqmw" entityName="AnInterfaceProvidedRole1">
+    <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+  </providedRoles_InterfaceProvidingEntity>
+</system:System>

--- a/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/twoInstancesOfSameSubsystemTransitively.system
+++ b/tests/org.palladiosimulator.pcm.tests/testmodels/Subsystem_Test/twoInstancesOfSameSubsystemTransitively.system
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="ASCII"?>
+<system:System xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:composition="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2" xmlns:repository="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" xmlns:subsystem="http://palladiosimulator.org/PalladioComponentModel/SubSystem/5.2" xmlns:system="http://palladiosimulator.org/PalladioComponentModel/System/5.2" id="_askwwFc3EeuCksbjIpnqmw" entityName="New System">
+  <assemblyContexts__ComposedStructure id="_c2YV4Fc3EeuCksbjIpnqmw" entityName="Assembly_ASubsystem">
+    <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_kKuccHgxEd6MsN0sq6tbVQ"/>
+  </assemblyContexts__ComposedStructure>
+  <assemblyContexts__ComposedStructure id="_duY78Fc3EeuCksbjIpnqmw" entityName="Assembly_ANestedSubsystem">
+    <encapsulatedComponent__AssemblyContext xsi:type="subsystem:SubSystem" href="default.repository#_uJ2_0H2nEd6u9Md61yj-5Q"/>
+  </assemblyContexts__ComposedStructure>
+  <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_g5oI4Fc3EeuCksbjIpnqmw" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_fPCPUFc3EeuCksbjIpnqmw" assemblyContext_ProvidedDelegationConnector="_duY78Fc3EeuCksbjIpnqmw">
+    <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_wFp-IH2nEd6u9Md61yj-5Q"/>
+  </connectors__ComposedStructure>
+  <connectors__ComposedStructure xsi:type="composition:ProvidedDelegationConnector" id="_hUpQ8Fc3EeuCksbjIpnqmw" entityName="newProvidedDelegationConnector" outerProvidedRole_ProvidedDelegationConnector="_fvsFUFc3EeuCksbjIpnqmw" assemblyContext_ProvidedDelegationConnector="_c2YV4Fc3EeuCksbjIpnqmw">
+    <innerProvidedRole_ProvidedDelegationConnector href="default.repository#_lthE4HgxEd6MsN0sq6tbVQ"/>
+  </connectors__ComposedStructure>
+  <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_fPCPUFc3EeuCksbjIpnqmw" entityName="AnInterfaceProvidedRole">
+    <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+  </providedRoles_InterfaceProvidingEntity>
+  <providedRoles_InterfaceProvidingEntity xsi:type="repository:OperationProvidedRole" id="_fvsFUFc3EeuCksbjIpnqmw" entityName="AnInterfaceProvidedRole1">
+    <providedInterface__OperationProvidedRole href="default.repository#_n7g-oCHbEd62GabW1zGSBw"/>
+  </providedRoles_InterfaceProvidingEntity>
+</system:System>


### PR DESCRIPTION
This PR addressed [PALLADIO-522](https://palladio-simulator.atlassian.net/browse/PALLADIO-522).

The constraint collects all instantiated RepositoryComponents by looking up assembly contexts. Afterwards, it filters for subsystems and checks if there is a duplicate. A duplicate means a violation.

Unfortunately, implementing the constraint in OCL is not possible (at least with the OCL knowledge I have). Closures of OCL are not sufficient because they yield a set of elements, which removes duplicates that we actually would like to find. Therefore, I created the constraint using Java.