### PR TITLE
Include extensionpoint schema in binary

### DIFF
--- a/bundles/org.palladiosimulator.pcm/build.properties
+++ b/bundles/org.palladiosimulator.pcm/build.properties
@@ -6,7 +6,8 @@ bin.includes = .,\
                model/,\
                META-INF/,\
                plugin.xml,\
-               plugin.properties
+               plugin.properties,\
+               schema/
 jars.compile.order = .
 source.. = src/,\
            src-gen/,\


### PR DESCRIPTION
The extension point schemas should be included in the binary jar, as they are required by eclipse to provide editing support.