### PR TITLE
COMMONS-41 Proper handling of null specifications in PCMRandomVariableImpl

### DIFF
--- a/bundles/org.palladiosimulator.pcm/src/org/palladiosimulator/pcm/core/impl/PCMRandomVariableImpl.java
+++ b/bundles/org.palladiosimulator.pcm/src/org/palladiosimulator/pcm/core/impl/PCMRandomVariableImpl.java
@@ -42,7 +42,7 @@ public class PCMRandomVariableImpl extends PCMRandomVariableImplGen {
                 e = null;
             }
             this.lastParseExpression = e;
-            this.lastParsedSpecification = new String(this.getSpecification());
+            this.lastParsedSpecification = this.getSpecification();
         }
         return this.lastParseExpression;
     }

--- a/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/core/impl/PCMRandomVariableTest.java
+++ b/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/core/impl/PCMRandomVariableTest.java
@@ -30,4 +30,19 @@ public class PCMRandomVariableTest extends TestBase {
         assertThat(parsedExpression, is(nullValue()));
     }
 
+    @Test
+    public void testReturnNullOnNullSpecification() {
+        var variable = CoreFactory.eINSTANCE.createPCMRandomVariable();
+        var parsedExpression = variable.getExpression();
+        assertThat(parsedExpression, is(nullValue()));
+    }
+
+    @Test
+    public void testReturnNullOnBlankSpecification() {
+        var variable = CoreFactory.eINSTANCE.createPCMRandomVariable();
+        variable.setSpecification("\t");
+        var parsedExpression = variable.getExpression();
+        assertThat(parsedExpression, is(nullValue()));
+    }
+
 }


### PR DESCRIPTION
Please refer to the [JIRA issue](https://palladio-simulator.atlassian.net/browse/COMMONS-41) for the rationale behind the changes.

This pull request depends on the changes in PalladioSimulator/Palladio-Core-Commons#29 and can only be built after merging the other pull request..