### PR TITLE
PALLADIO-546 Add EObject as base class for all PCM elements.

### DIFF
--- a/bundles/org.palladiosimulator.pcm/model/pcm.ecore
+++ b/bundles/org.palladiosimulator.pcm/model/pcm.ecore
@@ -5,7 +5,13 @@
   <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
     <details key="documentation" value="This package is the root package of all packages of the Palladio Component Model (PCM)."/>
   </eAnnotations>
-  <eClassifiers xsi:type="ecore:EClass" name="DummyClass"/>
+  <eClassifiers xsi:type="ecore:EClass" name="PCMBaseClass" abstract="true" eSuperTypes="#//PCMClass platform:/plugin/org.eclipse.emf.ecore/model/Ecore.ecore#//EObject">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="Common base for all EClass instances of PCM.&#xA;&#xA;The sole purpose of the class is to represent the inheritance relationship&#xA;to EObject. Making inheritance from EObject explicit is necessary to safely&#xA;cast instances of PCM meta classes to EObject in reflective scenarios such&#xA;as OCL evaluations.&#xA;&#xA;It is important to not define EObject as first super type. If doing so, EObject&#xA;will always be used as super class during the code generation. This ignores&#xA;the configured superclass in the genmodel. By referring to an empty EClass&#xA;in the first place, the super class defined in the genmodel is used."/>
+    </eAnnotations>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PCMClass" abstract="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="DummyClass" eSuperTypes="#//PCMBaseClass"/>
   <eSubpackages name="core" nsURI="http://palladiosimulator.org/PalladioComponentModel/Core/5.2"
       nsPrefix="core">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -14,7 +20,7 @@
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="validationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
     </eAnnotations>
-    <eClassifiers xsi:type="ecore:EClass" name="PCMRandomVariable" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.stoex/model/stoex.ecore#//RandomVariable">
+    <eClassifiers xsi:type="ecore:EClass" name="PCMRandomVariable" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.stoex/model/stoex.ecore#//RandomVariable #//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Random variables are used to describe user and component behaviour. They allow not only constant values (e.g., 3 loop iterations), but also probabilistic values (e.g., 2 loop iterations with a probability of 0.4 and 3 loop iterations with a probability of 0.6). They are well-suited for capturing uncertainty when modelling systems during early development stages. Examples where developers may use random variables are:&#xD;&#xA;- Characterisations of Input Parameters: Describes the QoS relevant characteristics of parameters of component services.&#xD;&#xA;- Inter-Arrival Time: Describes how much time passes between the arrival of two subsequent users.&#xD;&#xA;- Think Time: Describes how much time passes between the execution of a user scenario and the start of the next execution of this scenario.&#xD;&#xA;- Loop Iteration Count: Describes the number of repetitions of a loop.&#xD;&#xA;- Guarded Branch Transitions: Used to determine whether to conditionally execute a certain behaviour.&#xD;&#xA;&#xD;&#xA;PCMRandomVariable extends RandomVariable in a way, that the only type of variables available in the PCMRandomVariable are references to variable characterisations like a.NUMBER_OF_ELEMENTS. The corresponding editors ensure that the user can enter only valid expressions."/>
       </eAnnotations>
@@ -143,7 +149,7 @@
           <details key="constraints" value="operationProvidedRolesMustBeBound"/>
         </eAnnotations>
       </eClassifiers>
-      <eClassifiers xsi:type="ecore:EClass" name="NamedElement" abstract="true">
+      <eClassifiers xsi:type="ecore:EClass" name="NamedElement" abstract="true" eSuperTypes="#//PCMBaseClass">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
           <details key="documentation" value="The NamedElement meta class is inherited by all PCM classes whose instances bear a name. Thus, the semantic of &quot;bearing a name&quot; is given to all inheriting classes, so that the name can be used in visualisations, for example. "/>
         </eAnnotations>
@@ -222,7 +228,8 @@
             ordered="false" upperBound="-1" eType="#//core/composition/Connector"
             containment="true" eOpposite="#//core/composition/Connector/parentStructure__Connector"/>
       </eClassifiers>
-      <eClassifiers xsi:type="ecore:EClass" name="ResourceRequiredDelegationConnector">
+      <eClassifiers xsi:type="ecore:EClass" name="ResourceRequiredDelegationConnector"
+          eSuperTypes="#//PCMBaseClass">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
           <details key="documentation" value="TODO Michael Hauck"/>
         </eAnnotations>
@@ -440,7 +447,7 @@
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="validationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
     </eAnnotations>
-    <eClassifiers xsi:type="ecore:EClass" name="Workload" abstract="true">
+    <eClassifiers xsi:type="ecore:EClass" name="Workload" abstract="true" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="A Workload specifies the usage intensity of a system, which relates to the number of users concurrently&#xD;&#xA;present in the system. The PCM usage model adopts this concept from classical queueing&#xD;&#xA;theory [123]. The specified workloads can directly be used in queueing networks or easily be mapped&#xD;&#xA;to markings in stochastic Petri nets. Workloads can either be open or closed.&#xD;&#xA;&#xD;&#xA;The algorithms used to analyse queueing networks differ depending on whether open or closed workloads&#xD;&#xA;are modelled [123]. Some special queueing networks can only be analysed given a particular workload&#xD;&#xA;type (open or closed). Notice, that it is possible to specify a usage model with open workload usage&#xD;&#xA;scenarios and closed workload usage scenarios at the same time. Open and closed workloads can be&#xD;&#xA;executed in parallel when analysing the model.&#xD;&#xA;&#xD;&#xA;[123] E. Lazowska, J. Zahorjan, G. Graham, and K. Sevcik, Quantitative System Performance. Prentice&#xD;&#xA;Hall, 1984."/>
       </eAnnotations>
@@ -460,7 +467,7 @@
           ordered="false" lowerBound="1" eType="#//usagemodel/Workload" containment="true"
           eOpposite="#//usagemodel/Workload/usageScenario_Workload"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="UserData">
+    <eClassifiers xsi:type="ecore:EClass" name="UserData" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="UserData characterises data&#xD;&#xA;used in specific assembly contexts in the system. This data is the same for all UsageScenarios, i.e.,&#xD;&#xA;multiple users accessing the same components access the same data. This UserData refers to component&#xD;&#xA;parameters of the system publicized by the software architect (see pcm::parameters package). The domain expert&#xD;&#xA;characterises the values of component parameters related to business concepts (e.g., user specific data,&#xD;&#xA;data specific for a business domain), whereas the software architect characterises the values of component&#xD;&#xA;parameters related to technical concepts (e.g., size of caches, size of a thread pool, configuration data,&#xD;&#xA;etc.). One UserData instance includes all parameter characterisation for the annotated entity. "/>
       </eAnnotations>
@@ -472,7 +479,7 @@
           ordered="false" upperBound="-1" eType="#//parameter/VariableUsage" containment="true"
           eOpposite="#//parameter/VariableUsage/userData_VariableUsage"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="UsageModel">
+    <eClassifiers xsi:type="ecore:EClass" name="UsageModel" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The UsageModel specifies the whole user interaction with a system from a performance viewpoint. It consists of a number of concurrently executed UsageScenarios and a set of global UserData specifications. Each UsageScenario includes a workload and a scenario behaviour. "/>
       </eAnnotations>
@@ -554,7 +561,7 @@
           ordered="false" upperBound="-1" eType="#//usagemodel/AbstractUserAction"
           containment="true" eOpposite="#//usagemodel/AbstractUserAction/scenarioBehaviour_AbstractUserAction"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="BranchTransition">
+    <eClassifiers xsi:type="ecore:EClass" name="BranchTransition" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="The BranchTransition is an association class that realises the containment of ScenarioBehaviours in in the branches of a Branch action. It is a separate meta class because it has the additional attribute branchProbability that specifies how probably it is that the references ScenarioBehaviour is executed in the Branch action. &#xD;&#xA;&#xD;&#xA;See also Branch."/>
       </eAnnotations>
@@ -758,7 +765,7 @@
         </eAnnotations>
       </eStructuralFeatures>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="Parameter">
+    <eClassifiers xsi:type="ecore:EClass" name="Parameter" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="This entity represents a parameter within a signature. The parameter has a name and it is of a data type."/>
       </eAnnotations>
@@ -793,7 +800,7 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="resourceSignature__Parameter"
           ordered="false" eType="#//resourcetype/ResourceSignature" eOpposite="#//resourcetype/ResourceSignature/parameter__ResourceSignature"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="DataType" abstract="true">
+    <eClassifiers xsi:type="ecore:EClass" name="DataType" abstract="true" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="This entity represents a data type that can be stored in a repository and used for specification and modeling of interface signatures."/>
       </eAnnotations>
@@ -890,7 +897,7 @@
         </eAnnotations>
       </eStructuralFeatures>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="RequiredCharacterisation">
+    <eClassifiers xsi:type="ecore:EClass" name="RequiredCharacterisation" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Specification of required variable characeterisations per parameter. Increases power of interfaces and lifts variable characterisations to the interface to enable extended interoperability checks."/>
       </eAnnotations>
@@ -936,7 +943,7 @@
         </eAnnotations>
       </eStructuralFeatures>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="ExceptionType">
+    <eClassifiers xsi:type="ecore:EClass" name="ExceptionType" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="This entity represents a type of an exception."/>
       </eAnnotations>
@@ -1232,7 +1239,7 @@
           ordered="false" lowerBound="1" eType="#//resourcetype/ResourceRepository"
           eOpposite="#//resourcetype/ResourceRepository/availableResourceTypes_ResourceRepository"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="ResourceRepository">
+    <eClassifiers xsi:type="ecore:EClass" name="ResourceRepository" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Extendable repository of resource types of the PCM. The resource type repository is intentionally left open to support&#xD;&#xA;arbitrary resources in the future"/>
       </eAnnotations>
@@ -1292,7 +1299,7 @@
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="The parameter package allows to model data dependent performance characteristics of software systems. It is mainly used to specify performance dependencies on input and output parameters of single service calls. It can also be used to describe dependencies on the state of components by the use of component parameters. The latter describe stochastically a component state which does not change over time. &#xD;&#xA;&#xD;&#xA;Parameters are described by the use of variable usages which on the one side contain a performance abstraction of the variable's value and on the other side the name of the variable for refering to the variable. Characterisations available include Structure (information on the data's internal structure like &quot;sorted&quot; or &quot;unsorted&quot; for an array), Number of Elements (size of a collection), Value (the actuall variable value), Bytesize (the variable's memory footprint), or type (the type of the variable in polymorphic cases).&#xD;&#xA;&#xD;&#xA;Example for variable usages may be a.NUMBER_OF_ELEMENTS = 10 (array &quot;a&quot; contains 10 elements), tree.STRUCTURE = &quot;balanced&quot; (tree &quot;tree&quot; is a balanced tree), and so on."/>
     </eAnnotations>
-    <eClassifiers xsi:type="ecore:EClass" name="VariableUsage">
+    <eClassifiers xsi:type="ecore:EClass" name="VariableUsage" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Variable usages are used to characterise variables like input and output variables or component parameters. They contain the specification of the variable as VariableCharacterisation and also refer to the name of the characterised variable in its namedReference association. Note that it was an explicit design decision to refer to variable names instead of the actual variables (i.e., by refering to Parameter class). It eased the writing of transformations (DSolver as well as SimuCom) but put some complexity in the frontend for entering the variable usages."/>
       </eAnnotations>
@@ -1326,7 +1333,7 @@
           ordered="false" lowerBound="1" eType="ecore:EClass platform:/plugin/de.uka.ipd.sdq.stoex/model/stoex.ecore#//AbstractNamedReference"
           containment="true"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="VariableCharacterisation">
+    <eClassifiers xsi:type="ecore:EClass" name="VariableCharacterisation" eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Variable characterisations store performance critical meta-information on a variable. For example, if a variable's value is used in a long running loop, the value of the variable is performance critical. Or as an other example, for Q-Sort it is performancewise important to know how much elements are in a given array and whether the array is sorted or not. Variable characterisations contain a type which tells what kind of meta-information is stored (STRUCTURE, NUMBER_OF_ELEMENTS, ...) and a PCMRandomVariable for storing the value of the characterisation.&#xD;&#xA;&#xD;&#xA;For example, in &quot;a.NUMBER_OF_ELEMENTS=10&quot; the a is the name of the variable, NUMBER_OF_ELEMENTS is the characterisation type and &quot;10&quot; would be the specification (as PCMRandomVariable) of the characterisation's value."/>
       </eAnnotations>
@@ -1346,7 +1353,7 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="variableUsage_VariableCharacterisation"
           ordered="false" eType="#//parameter/VariableUsage" eOpposite="#//parameter/VariableUsage/variableCharacterisation_VariableUsage"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="CharacterisedVariable" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.stoex/model/stoex.ecore#//Variable">
+    <eClassifiers xsi:type="ecore:EClass" name="CharacterisedVariable" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.stoex/model/stoex.ecore#//Variable #//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="A characterised variable is a special variable which contains a performance abstraction of a data type. It can be transformed in a named reference and a variable characterisation. It has to end always with a variable characterisation type. Examples are &quot;a.NUMBER_OF_ELEMENTS&quot; or &quot;array.STRUCTURE&quot;."/>
       </eAnnotations>
@@ -1396,7 +1403,8 @@
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="validationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
     </eAnnotations>
-    <eClassifiers xsi:type="ecore:EClass" name="FailureOccurrenceDescription" abstract="true">
+    <eClassifiers xsi:type="ecore:EClass" name="FailureOccurrenceDescription" abstract="true"
+        eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="&lt;p>&#xD;&#xA;    Abstract superclass that connects a failure type definition to an occurrence probability. Used to describe the failure&#xD;&#xA;    potential of certain points of failure within the control and data flow (i.e. Actions within&#xD;&#xA;    ResourceDemandingBehaviours).&#xD;&#xA;&lt;/p>"/>
       </eAnnotations>
@@ -1545,7 +1553,7 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="resourceDemandingBehaviour_AbstractAction"
           ordered="false" eType="#//seff/ResourceDemandingBehaviour" eOpposite="#//seff/ResourceDemandingBehaviour/steps_Behaviour"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="ResourceDemandingBehaviour" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier">
+    <eClassifiers xsi:type="ecore:EClass" name="ResourceDemandingBehaviour" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier #//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Models the behaviour of a component service as a sequence of internal actions with resource demands, control flow constructs, and external&#xD;&#xA;calls. Therefore, the class contains a chain of AbstractActions. The emphasis in this type of behaviour is on the resource demands attached to internal actions, which mainly influence performance analysis.&#xD;&#xA;Each action in a ResourceDemandingBehaviour references a predecessor and a successor action. Exceptions are the first and last action, which do not reference a predecessor and a successor respectively. A behaviour is valid, if there is a continuous path from the first to last action, which includes all actions. The chain must not include cycles. To specify control flow branches, loops, or forks, component developers need to use special types of actions, which contain nested inner ResourceDemandingBehaviours to specify the behaviour inside branches or loop bodies. Any ResourceDemandingBehaviour can have at most one starting and one finishing action."/>
       </eAnnotations>
@@ -1703,7 +1711,7 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="forkAction_ForkedBehaivour"
           ordered="false" eType="#//seff/ForkAction" eOpposite="#//seff/ForkAction/asynchronousForkedBehaviours_ForkAction"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="SynchronisationPoint" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier">
+    <eClassifiers xsi:type="ecore:EClass" name="SynchronisationPoint" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier #//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Component developers can use a SynchronisationPoint to join synchronously ForkedBehaviours and specify a result of the computations with its attached VariableUsages.&#xD;&#xA;See ForkAction for a more detailed description. "/>
       </eAnnotations>
@@ -1883,7 +1891,7 @@
             ordered="false" lowerBound="1" eType="#//core/PCMRandomVariable" containment="true"
             eOpposite="#//core/PCMRandomVariable/resourceCall__PCMRandomVariable"/>
       </eClassifiers>
-      <eClassifiers xsi:type="ecore:EClass" name="ParametricResourceDemand">
+      <eClassifiers xsi:type="ecore:EClass" name="ParametricResourceDemand" eSuperTypes="#//PCMBaseClass">
         <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
           <details key="documentation" value="TODO&amp;nbsp;(Überarbeitung&amp;nbsp;durch&amp;nbsp;MH)&lt;br />&#xD;&#xA;Parametric&amp;nbsp;Resource&amp;nbsp;Demand&amp;nbsp;Specifies&amp;nbsp;the&amp;nbsp;amount&amp;nbsp;of&amp;nbsp;processing&amp;nbsp;requested&amp;nbsp;from&amp;nbsp;a&amp;nbsp;certain&amp;nbsp;type&amp;nbsp;of&amp;nbsp;resource&amp;nbsp;in&amp;nbsp;a&amp;nbsp;parametrised&amp;nbsp;way.&amp;nbsp;It&amp;nbsp;assigns&amp;nbsp;the&amp;nbsp;demand&amp;nbsp;specified&amp;nbsp;as&amp;nbsp;a&amp;nbsp;Random-Variable&amp;nbsp;to&amp;nbsp;an&amp;nbsp;abstract&amp;nbsp;ProcessingResourceType&amp;nbsp;(e.g.,&amp;nbsp;CPU,&amp;nbsp;hard&amp;nbsp;disk)&amp;nbsp;instead&amp;nbsp;of&amp;nbsp;a&amp;nbsp;concrete&amp;nbsp;ProcessingResourceSpecification&amp;nbsp;(e.g.,&amp;nbsp;5&amp;nbsp;Ghz&amp;nbsp;CPU,&amp;nbsp;20&amp;nbsp;MByte/s&amp;nbsp;hard&amp;nbsp;disk).&amp;nbsp;This&amp;nbsp;keeps&amp;nbsp;the&amp;nbsp;RDSEFF&amp;nbsp;independent&amp;nbsp;from&amp;nbsp;a&amp;nbsp;specific&amp;nbsp;resource&amp;nbsp;environment,&amp;nbsp;and&amp;nbsp;makes&amp;nbsp;the&amp;nbsp;concrete&amp;nbsp;resources&amp;nbsp;replaceable&amp;nbsp;to&amp;nbsp;answer&amp;nbsp;sizing&amp;nbsp;questions.&lt;br />&#xD;&#xA;The&amp;nbsp;demand's&amp;nbsp;unit&amp;nbsp;is&amp;nbsp;equal&amp;nbsp;for&amp;nbsp;all&amp;nbsp;ProcessingResourceSpecifications&amp;nbsp;referencing&lt;br />&#xD;&#xA;the&amp;nbsp;same&amp;nbsp;ProcessingResourceType.&amp;nbsp;It&amp;nbsp;can&amp;nbsp;for&amp;nbsp;example&amp;nbsp;be&amp;nbsp;&quot;WorkUnits&quot;&lt;br />&#xD;&#xA;for&amp;nbsp;CPUs&amp;nbsp;[Smi02]&amp;nbsp;or&amp;nbsp;&quot;BytesRead&quot;&amp;nbsp;for&amp;nbsp;hard&amp;nbsp;disks.&amp;nbsp;Each&amp;nbsp;ProcessingResource-&lt;br />&#xD;&#xA;Specification&amp;nbsp;contains&amp;nbsp;a&amp;nbsp;processing&amp;nbsp;rate&amp;nbsp;for&amp;nbsp;demands&amp;nbsp;(e.g.,&amp;nbsp;1000&amp;nbsp;WorkUnits/s,&amp;nbsp;20&lt;br />&#xD;&#xA;MB/s),&amp;nbsp;which&amp;nbsp;analysis&amp;nbsp;tools&amp;nbsp;use&amp;nbsp;to&amp;nbsp;compute&amp;nbsp;an&amp;nbsp;actual&amp;nbsp;timing&amp;nbsp;value&amp;nbsp;in&amp;nbsp;seconds.&amp;nbsp;They&lt;br />&#xD;&#xA;use&amp;nbsp;this&amp;nbsp;timing&amp;nbsp;value&amp;nbsp;for&amp;nbsp;example&amp;nbsp;as&amp;nbsp;the&amp;nbsp;service&amp;nbsp;demand&amp;nbsp;on&amp;nbsp;a&amp;nbsp;service&amp;nbsp;center&amp;nbsp;in&amp;nbsp;a&amp;nbsp;queueing&lt;br />&#xD;&#xA;network&amp;nbsp;or&amp;nbsp;the&amp;nbsp;firing&amp;nbsp;delay&amp;nbsp;of&amp;nbsp;a&amp;nbsp;transition&amp;nbsp;in&amp;nbsp;a&amp;nbsp;Petri&amp;nbsp;net.&amp;nbsp;As&amp;nbsp;multiple&amp;nbsp;component&amp;nbsp;services&lt;br />&#xD;&#xA;might&amp;nbsp;request&amp;nbsp;processing&amp;nbsp;on&amp;nbsp;the&amp;nbsp;same&amp;nbsp;resource,&amp;nbsp;these&amp;nbsp;analytical&amp;nbsp;or&amp;nbsp;simulation&amp;nbsp;models&lt;br />&#xD;&#xA;allow&amp;nbsp;determining&amp;nbsp;the&amp;nbsp;waiting&amp;nbsp;delay&amp;nbsp;induced&amp;nbsp;by&amp;nbsp;this&amp;nbsp;contention&amp;nbsp;effect.&lt;br />&#xD;&#xA;Besides&amp;nbsp;this&amp;nbsp;parameterisation&amp;nbsp;over&amp;nbsp;different&amp;nbsp;resource&amp;nbsp;environments,&amp;nbsp;Parametric-&lt;br />&#xD;&#xA;ResourceDemands&amp;nbsp;also&amp;nbsp;parameterise&amp;nbsp;over&amp;nbsp;the&amp;nbsp;usage&amp;nbsp;profile.&amp;nbsp;For&amp;nbsp;this,&amp;nbsp;the&amp;nbsp;stochastic&amp;nbsp;expression&lt;br />&#xD;&#xA;specifying&amp;nbsp;the&amp;nbsp;resource&amp;nbsp;demand&amp;nbsp;can&amp;nbsp;contain&amp;nbsp;references&amp;nbsp;to&amp;nbsp;the&amp;nbsp;service's&amp;nbsp;input&lt;br />&#xD;&#xA;parameters&amp;nbsp;or&amp;nbsp;the&amp;nbsp;component&amp;nbsp;parameters.&amp;nbsp;Upon&amp;nbsp;evaluating&amp;nbsp;the&amp;nbsp;resource&amp;nbsp;demand,&amp;nbsp;analysis&lt;br />&#xD;&#xA;tools&amp;nbsp;use&amp;nbsp;the&amp;nbsp;current&amp;nbsp;characterisation&amp;nbsp;of&amp;nbsp;the&amp;nbsp;referenced&amp;nbsp;input&amp;nbsp;or&amp;nbsp;component&amp;nbsp;parameter&lt;br />&#xD;&#xA;and&amp;nbsp;substitute&amp;nbsp;the&amp;nbsp;reference&amp;nbsp;with&amp;nbsp;this&amp;nbsp;characterisation&amp;nbsp;in&amp;nbsp;the&amp;nbsp;stochastic&amp;nbsp;expression.&lt;br />&#xD;&#xA;Solving&amp;nbsp;the&amp;nbsp;stochastic&amp;nbsp;expression,&amp;nbsp;which&amp;nbsp;can&amp;nbsp;be&amp;nbsp;a&amp;nbsp;function&amp;nbsp;involving&amp;nbsp;arithmetic&amp;nbsp;operators&lt;br />&#xD;&#xA;(Chapter&amp;nbsp;3.3.6),&amp;nbsp;then&amp;nbsp;yields&amp;nbsp;a&amp;nbsp;constant&amp;nbsp;or&amp;nbsp;probability&amp;nbsp;function&amp;nbsp;for&amp;nbsp;the&amp;nbsp;resource&amp;nbsp;demand.&lt;br />&#xD;&#xA;As&amp;nbsp;an&amp;nbsp;example&amp;nbsp;for&amp;nbsp;solving&amp;nbsp;the&amp;nbsp;parameterisation&amp;nbsp;over&amp;nbsp;resource&amp;nbsp;environment&amp;nbsp;and&amp;nbsp;usage&lt;br />&#xD;&#xA;profile,&amp;nbsp;consider&amp;nbsp;an&amp;nbsp;RDSEFF&amp;nbsp;for&amp;nbsp;a&amp;nbsp;service&amp;nbsp;implementing&amp;nbsp;the&amp;nbsp;bubblesort&amp;nbsp;algorithm.&amp;nbsp;It&lt;br />&#xD;&#xA;might&amp;nbsp;include&amp;nbsp;a&amp;nbsp;CPU&amp;nbsp;demand&amp;nbsp;specification&amp;nbsp;of&amp;nbsp;n22000WorkUnits&amp;nbsp;derived&amp;nbsp;from&amp;nbsp;complexity&lt;br />&#xD;&#xA;theory&amp;nbsp;(n2)&amp;nbsp;and&amp;nbsp;empirical&amp;nbsp;measurements&amp;nbsp;(2000).&amp;nbsp;In&amp;nbsp;this&amp;nbsp;case&amp;nbsp;n&amp;nbsp;refers&amp;nbsp;to&amp;nbsp;the&amp;nbsp;length&amp;nbsp;of&lt;br />&#xD;&#xA;the&amp;nbsp;list&amp;nbsp;the&amp;nbsp;algorithm&amp;nbsp;shall&amp;nbsp;sort,&amp;nbsp;which&amp;nbsp;is&amp;nbsp;an&amp;nbsp;input&amp;nbsp;parameter&amp;nbsp;of&amp;nbsp;the&amp;nbsp;service.&amp;nbsp;If&amp;nbsp;the&amp;nbsp;current&lt;br />&#xD;&#xA;characterisation&amp;nbsp;of&amp;nbsp;the&amp;nbsp;list's&amp;nbsp;length&amp;nbsp;is&amp;nbsp;100&amp;nbsp;(as&amp;nbsp;the&amp;nbsp;modelled&amp;nbsp;usage&amp;nbsp;profile),&amp;nbsp;analysis&amp;nbsp;tools&lt;br />&#xD;&#xA;derive&amp;nbsp;1002&amp;nbsp;&amp;nbsp;2000&amp;nbsp;&amp;nbsp;12000&amp;nbsp;WorkUnits&amp;nbsp;from&amp;nbsp;the&amp;nbsp;specification,&amp;nbsp;thus&amp;nbsp;resolving&amp;nbsp;the&amp;nbsp;usage&lt;br />&#xD;&#xA;profile&amp;nbsp;dependency.&amp;nbsp;If&amp;nbsp;the&amp;nbsp;CPU&amp;nbsp;ProcessingResourceSpecification&amp;nbsp;the&amp;nbsp;service's&lt;br />&#xD;&#xA;126&lt;br />&#xD;&#xA;4.3.&amp;nbsp;Resource&amp;nbsp;Demanding&amp;nbsp;Service&amp;nbsp;Effect&amp;nbsp;Specification&lt;br />&#xD;&#xA;component&amp;nbsp;is&amp;nbsp;allocated&amp;nbsp;on&amp;nbsp;then&amp;nbsp;contains&amp;nbsp;a&amp;nbsp;processing&amp;nbsp;rate&amp;nbsp;of&amp;nbsp;10000WorkUnits/s,&amp;nbsp;analysis&lt;br />&#xD;&#xA;tools&amp;nbsp;derive&amp;nbsp;an&amp;nbsp;execution&amp;nbsp;time&amp;nbsp;of&amp;nbsp;12000&amp;nbsp;WorkUnits&amp;nbsp;{10000&amp;nbsp;WorkUnits/s&amp;nbsp;=&amp;nbsp;1:2&amp;nbsp;s&amp;nbsp;from&amp;nbsp;the&lt;br />&#xD;&#xA;specification,&amp;nbsp;thus&amp;nbsp;resolving&amp;nbsp;the&amp;nbsp;resource&amp;nbsp;environment&amp;nbsp;dependency.&lt;br />&#xD;&#xA;The&amp;nbsp;stochastic&amp;nbsp;expression&amp;nbsp;for&amp;nbsp;a&amp;nbsp;ParametricResourceDemand&amp;nbsp;depends&amp;nbsp;on&amp;nbsp;the&amp;nbsp;implementation&lt;br />&#xD;&#xA;of&amp;nbsp;the&amp;nbsp;service.&amp;nbsp;Component&amp;nbsp;developers&amp;nbsp;can&amp;nbsp;specify&amp;nbsp;it&amp;nbsp;using&amp;nbsp;complexity&amp;nbsp;theory,&lt;br />&#xD;&#xA;estimations,&amp;nbsp;or&amp;nbsp;measurements.&amp;nbsp;However,&amp;nbsp;how&amp;nbsp;to&amp;nbsp;get&amp;nbsp;data&amp;nbsp;to&amp;nbsp;define&amp;nbsp;such&amp;nbsp;expressions&lt;br />&#xD;&#xA;accurately&amp;nbsp;is&amp;nbsp;beyond&amp;nbsp;of&amp;nbsp;the&amp;nbsp;scope&amp;nbsp;of&amp;nbsp;this&amp;nbsp;thesis.&amp;nbsp;Woodside&amp;nbsp;et&amp;nbsp;al.&amp;nbsp;[WVCB01]&amp;nbsp;and&amp;nbsp;Krogmann&lt;br />&#xD;&#xA;[Kro07]&amp;nbsp;present&amp;nbsp;approaches&amp;nbsp;for&amp;nbsp;measuring&amp;nbsp;resource&amp;nbsp;demands&amp;nbsp;in&amp;nbsp;dependency&amp;nbsp;to&amp;nbsp;input&amp;nbsp;parameters.&lt;br />&#xD;&#xA;Meyerhoefer&amp;nbsp;et&amp;nbsp;al.&amp;nbsp;[ML05]&amp;nbsp;and&amp;nbsp;Kuperberg&amp;nbsp;et&amp;nbsp;al.&amp;nbsp;[KB07]&amp;nbsp;propose&amp;nbsp;methods&amp;nbsp;to&lt;br />&#xD;&#xA;establish&amp;nbsp;resource&amp;nbsp;demands&amp;nbsp;independent&amp;nbsp;from&amp;nbsp;concrete&amp;nbsp;resources.&amp;nbsp;For&amp;nbsp;the&amp;nbsp;scope&amp;nbsp;of&amp;nbsp;this&lt;br />&#xD;&#xA;thesis,&amp;nbsp;it&amp;nbsp;is&amp;nbsp;assumed&amp;nbsp;that&amp;nbsp;these&amp;nbsp;methods&amp;nbsp;have&amp;nbsp;been&amp;nbsp;applied&amp;nbsp;and&amp;nbsp;an&amp;nbsp;accurate&amp;nbsp;specification&lt;br />&#xD;&#xA;of&amp;nbsp;the&amp;nbsp;ParametricResourceDemand&amp;nbsp;is&amp;nbsp;available."/>
         </eAnnotations>
@@ -1962,7 +1970,8 @@
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="validationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
     </eAnnotations>
-    <eClassifiers xsi:type="ecore:EClass" name="SpecifiedQoSAnnotation" abstract="true">
+    <eClassifiers xsi:type="ecore:EClass" name="SpecifiedQoSAnnotation" abstract="true"
+        eSuperTypes="#//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="&lt;p>&#xD;&#xA;    SpecifiedQoSAnnotations&amp;nbsp;(as&amp;nbsp;an&amp;nbsp;abstract&amp;nbsp;class)&amp;nbsp;associate&amp;nbsp;specified&amp;nbsp;(see&amp;nbsp;QoSAnnotation)&amp;nbsp;QoS&amp;nbsp;properties&amp;nbsp;to&amp;nbsp;services&amp;nbsp;of&amp;nbsp;components.&amp;nbsp;A&amp;nbsp;service&amp;nbsp;is&amp;nbsp;thereby&amp;nbsp;determined&amp;nbsp;by&amp;nbsp;a&amp;nbsp;Signature&amp;nbsp;and&amp;nbsp;a&amp;nbsp;Role&amp;nbsp;(i.e.,&amp;nbsp;an&amp;nbsp;interface&amp;nbsp;bound&amp;nbsp;to&amp;nbsp;a&amp;nbsp;component).&#xD;&#xA;&lt;/p>"/>
       </eAnnotations>
@@ -2151,7 +2160,7 @@
           upperBound="-1" eType="#//resourceenvironment/HDDProcessingResourceSpecification"
           eOpposite="#//resourceenvironment/HDDProcessingResourceSpecification/resourceContainer"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="ProcessingResourceSpecification" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier">
+    <eClassifiers xsi:type="ecore:EClass" name="ProcessingResourceSpecification" eSuperTypes="platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier #//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Performance specification of processing resources (e.g. processing rate, scheduling policy)"/>
       </eAnnotations>
@@ -2194,7 +2203,7 @@
           eOpposite="#//resourceenvironment/ResourceContainer/activeResourceSpecifications_ResourceContainer"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="CommunicationLinkResourceSpecification"
-        eSuperTypes="platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier">
+        eSuperTypes="platform:/plugin/de.uka.ipd.sdq.identifier/model/identifier.ecore#//Identifier #//PCMBaseClass">
       <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
         <details key="documentation" value="Throughput and performance specification of linking resources"/>
       </eAnnotations>

--- a/bundles/org.palladiosimulator.pcm/model/pcm.genmodel
+++ b/bundles/org.palladiosimulator.pcm/model/pcm.genmodel
@@ -39,6 +39,8 @@
   <genPackages xsi:type="genmodel:GenPackage" prefix="Pcm" basePackage="org.palladiosimulator"
       resource="XMI" disposableProviderFactory="true" extensibleProviderFactory="true"
       childCreationExtenders="true" ecorePackage="pcm.ecore#/">
+    <genClasses xsi:type="genmodel:GenClass" image="false" ecoreClass="pcm.ecore#//PCMBaseClass"/>
+    <genClasses xsi:type="genmodel:GenClass" image="false" ecoreClass="pcm.ecore#//PCMClass"/>
     <genClasses xsi:type="genmodel:GenClass" ecoreClass="pcm.ecore#//DummyClass"/>
     <nestedGenPackages xsi:type="genmodel:GenPackage" prefix="Core" basePackage="org.palladiosimulator.pcm"
         resource="XMI" disposableProviderFactory="true" extensibleProviderFactory="true"
@@ -363,6 +365,10 @@
             createChild="false" ecoreFeature="ecore:EReference pcm.ecore#//usagemodel/ScenarioBehaviour/loop_ScenarioBehaviour"/>
         <genFeatures xsi:type="genmodel:GenFeature" property="None" children="true"
             createChild="true" ecoreFeature="ecore:EReference pcm.ecore#//usagemodel/ScenarioBehaviour/actions_ScenarioBehaviour"/>
+        <genOperations xsi:type="genmodel:GenOperation" ecoreOperation="pcm.ecore#//usagemodel/ScenarioBehaviour/routeFromStartToStopAction">
+          <genParameters xsi:type="genmodel:GenParameter" ecoreParameter="pcm.ecore#//usagemodel/ScenarioBehaviour/routeFromStartToStopAction/diagnostics"/>
+          <genParameters xsi:type="genmodel:GenParameter" ecoreParameter="pcm.ecore#//usagemodel/ScenarioBehaviour/routeFromStartToStopAction/context"/>
+        </genOperations>
       </genClasses>
       <genClasses xsi:type="genmodel:GenClass" ecoreClass="pcm.ecore#//usagemodel/BranchTransition">
         <genFeatures xsi:type="genmodel:GenFeature" createChild="false" ecoreFeature="ecore:EAttribute pcm.ecore#//usagemodel/BranchTransition/branchProbability"/>
@@ -498,6 +504,9 @@
             createChild="true" ecoreFeature="ecore:EReference pcm.ecore#//repository/Interface/requiredCharacterisations"/>
         <genFeatures xsi:type="genmodel:GenFeature" property="None" notify="false"
             createChild="false" ecoreFeature="ecore:EReference pcm.ecore#//repository/Interface/repository__Interface"/>
+        <genOperations xsi:type="genmodel:GenOperation" ecoreOperation="pcm.ecore#//repository/Interface/isAssignableFrom">
+          <genParameters xsi:type="genmodel:GenParameter" ecoreParameter="pcm.ecore#//repository/Interface/isAssignableFrom/otherInterface"/>
+        </genOperations>
       </genClasses>
       <genClasses xsi:type="genmodel:GenClass" ecoreClass="pcm.ecore#//repository/RequiredCharacterisation">
         <genFeatures xsi:type="genmodel:GenFeature" createChild="false" ecoreFeature="ecore:EAttribute pcm.ecore#//repository/RequiredCharacterisation/type"/>
@@ -796,6 +805,10 @@
             createChild="false" ecoreFeature="ecore:EReference pcm.ecore#//seff/ResourceDemandingBehaviour/abstractBranchTransition_ResourceDemandingBehaviour"/>
         <genFeatures xsi:type="genmodel:GenFeature" property="None" children="true"
             createChild="true" ecoreFeature="ecore:EReference pcm.ecore#//seff/ResourceDemandingBehaviour/steps_Behaviour"/>
+        <genOperations xsi:type="genmodel:GenOperation" ecoreOperation="pcm.ecore#//seff/ResourceDemandingBehaviour/startActionNeedsRouteToStopAction">
+          <genParameters xsi:type="genmodel:GenParameter" ecoreParameter="pcm.ecore#//seff/ResourceDemandingBehaviour/startActionNeedsRouteToStopAction/diagnostics"/>
+          <genParameters xsi:type="genmodel:GenParameter" ecoreParameter="pcm.ecore#//seff/ResourceDemandingBehaviour/startActionNeedsRouteToStopAction/context"/>
+        </genOperations>
       </genClasses>
       <genClasses xsi:type="genmodel:GenClass" image="false" ecoreClass="pcm.ecore#//seff/AbstractLoopAction"
           labelFeature="#//pcm/core/entity/NamedElement/entityName">

--- a/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/PCMPackageTest.java
+++ b/tests/org.palladiosimulator.pcm.tests/src/org/palladiosimulator/pcm/PCMPackageTest.java
@@ -1,0 +1,58 @@
+package org.palladiosimulator.pcm;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.junit.jupiter.api.Test;
+
+public class PCMPackageTest {
+
+    /**
+     * This test ensures that all EClass instances contained in the {@link PcmPackage} inherit from
+     * EObject.
+     */
+    @Test
+    public void testThatAllMetaClassesAreEObjects() {
+        Set<EClass> nonEObjectEClasses = new LinkedHashSet<>();
+
+        // iterate through the whole PCM package
+        EObject currentEObject = PcmPackage.eINSTANCE;
+        for (TreeIterator<EObject> iter = PcmPackage.eINSTANCE.eAllContents(); iter
+            .hasNext(); currentEObject = iter.next()) {
+
+            // we are only interested in EClasses
+            if (!(currentEObject instanceof EClass)) {
+                continue;
+            }
+            EClass currentEClass = (EClass) currentEObject;
+
+            // skip all non-concrete EClasses 
+            if (currentEClass.isAbstract() || currentEClass.isInterface()) {
+                continue;
+            }
+
+            // record EClasses that do not inherit from EObject transitively
+            if (!currentEClass.getEAllSuperTypes()
+                .contains(EcorePackage.eINSTANCE.getEObject())) {
+                nonEObjectEClasses.add(currentEClass);
+            }
+
+        }
+
+        // assert that no problematic classes exist
+        String classNamesMessagePart = nonEObjectEClasses.stream()
+            .map(c -> c.getName() + "(" + c.getEPackage()
+                .getNsURI() + ")")
+            .collect(Collectors.joining(System.lineSeparator()));
+        assertTrue(nonEObjectEClasses.isEmpty(), "There are EClasses that do not inherit from EObject:"
+                + System.lineSeparator() + classNamesMessagePart);
+    }
+
+}


### PR DESCRIPTION
This PR partially addresses [PALLADIO-546](https://palladio-simulator.atlassian.net/browse/PALLADIO-546). The validation using Pivot OCL cannot handle casts to EObject because it only operates on the metamodel in a reflective way. Therefore, it is not aware of the base class, which is only added during the code generation. To keep compatibility with existing constraints, this PR introduces EObject as base class for all concrete EClasses in the PCM metamodel.

PalladioSimulator/Palladio-Bench-Product#19 provides the means to use Pivot OCL in the PCM product.