### PR TITLE
Migrate to parent POM version 0.11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
     with:
       use-display-output: true
       no-caching: true
+      runner-label: self-hosted
       deploy-updatesite: 'releng/org.palladiosimulator.pcm.updatesite/target/repository'
     secrets:
       SERVER_SSH_KEY: ${{ secrets.DEPLOYMENT_SERVER_SSH_KEY }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.5</version>
+		<version>4.0.13</version>
 	</extension>
 </extensions>

--- a/bundles/org.palladiosimulator.pcm.edp2.measuringpoint/model/pcmmeasuringpoint.genmodel
+++ b/bundles/org.palladiosimulator.pcm.edp2.measuringpoint/model/pcmmeasuringpoint.genmodel
@@ -4,7 +4,7 @@
     modelPluginID="org.palladiosimulator.pcm.edp2.measuringpoint" modelName="Pcmmeasuringpoint"
     rootExtendsInterface="org.eclipse.emf.cdo.CDOObject" rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl"
     codeFormatting="true" importerID="org.eclipse.emf.importer.ecore" featureDelegation="Dynamic"
-    complianceLevel="6.0" copyrightFields="false" usedGenPackages="../../org.palladiosimulator.edp2/model/EDP2.genmodel#//models ../../de.uka.ipd.sdq.identifier/model/identifier.genmodel#//identifier ../../org.palladiosimulator.metricspec/model/metricspec.genmodel#//metricspec ../../org.palladiosimulator.pcm/model/pcm.genmodel#//pcm ../../de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel#//probfunction ../../de.uka.ipd.sdq.stoex/model/stoex.genmodel#//stoex ../../de.uka.ipd.sdq.units/model/Units.genmodel#//units"
+    complianceLevel="17.0" copyrightFields="false" usedGenPackages="../../org.palladiosimulator.edp2/model/EDP2.genmodel#//models ../../de.uka.ipd.sdq.identifier/model/identifier.genmodel#//identifier ../../org.palladiosimulator.metricspec/model/metricspec.genmodel#//metricspec ../../org.palladiosimulator.pcm/model/pcm.genmodel#//pcm ../../de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel#//probfunction ../../de.uka.ipd.sdq.stoex/model/stoex.genmodel#//stoex ../../de.uka.ipd.sdq.units/model/Units.genmodel#//units"
     importOrganizing="true" cleanup="true">
   <foreignModel>pcmmeasuringpoint.ecore</foreignModel>
   <modelPluginVariables>CDO=org.eclipse.emf.cdo</modelPluginVariables>

--- a/features/org.palladiosimulator.pcm.feature/pom.xml
+++ b/features/org.palladiosimulator.pcm.feature/pom.xml
@@ -14,14 +14,14 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<executions>
 					<execution>
-						<id>source-feature</id>
+						<id>feature-source</id>
 						<goals>
-							<goal>source-feature</goal>
+							<goal>feature-source</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
-		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.10.1</version>
+		<artifactId>repository-parent</artifactId>
+		<version>0.11.0</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator.pcm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
 		<version>0.10.1</version>
+		<relativePath/>
 	</parent>
 	<groupId>org.palladiosimulator.pcm</groupId>
 	<artifactId>parent</artifactId>	

--- a/releng/org.palladiosimulator.pcm.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.pcm.targetplatform/tp.target
@@ -66,7 +66,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<unit id="de.itemis.xtext.antlr.feature.feature.group" version="0.0.0"/>
-			<repository location="http://download.itemis.com/updates/releases/2.1.1"/>
+			<repository location="https://artifacts.itemis.cloud/repository/p2/xtext-updates/releases/2.1.1"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
- Add empty `<relativePath/>` to the parent POM to avoid Maven warnings about mismatched parent resolution.
- Update Tycho version in `.mvn/extensions.xml` to `4.0.13`.
- Update Itemis Xtext repository location in `tp.target` from `http://download.itemis.com/updates/releases/2.1.1` to `https://artifacts.itemis.cloud/repository/p2/xtext-updates/releases/2.1.1`.
- Replace `org.eclipse.tycho.extras:tycho-source-feature-plugin` with `org.eclipse.tycho:tycho-source-plugin` in `pom.xml` files and update the execution goal from `source-feature` to `feature-source`.
- Set `complianceLevel` to `17.0` in `.genmodel` files.
- Migrate from parent POM `eclipse-parent-updatesite` version `0.10.1` to `repository-parent` version `0.11.0`.